### PR TITLE
Initial work on metrics server auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ defmodule MyCoolAppWeb.Endpoint do
   ...
 
   plug PromEx.Plug, prom_ex_module: MyCoolApp.PromEx
-  # Or plug PromEx.plug, path: "/some/other/non-standard/path", prom_ex_module: MyCoolApp.PromEx
+  # Or plug PromEx.plug, path: "/some/other/metrics/path", prom_ex_module: MyCoolApp.PromEx
 
   ...
 

--- a/lib/prom_ex.ex
+++ b/lib/prom_ex.ex
@@ -344,7 +344,16 @@ defmodule PromEx do
           raise "Invalid :protocol config value provided to PromEx.MetricsServer (valid values are :http and :https)"
       end
 
-    plug_definition = {PromEx.MetricsServer.Plug, path: config.path, prom_ex_module: prom_ex_module}
+    plug_opts = %{
+      path: config.path,
+      prom_ex_module: prom_ex_module,
+      auth_strategy: Map.get(config, :auth_strategy),
+      auth_token: Map.get(config, :auth_token),
+      auth_user: Map.get(config, :auth_user),
+      auth_password: Map.get(config, :auth_password)
+    }
+
+    plug_definition = {PromEx.MetricsServer.Plug, plug_opts}
 
     spec =
       Plug.Cowboy.child_spec(

--- a/lib/prom_ex/metrics_server/plug.ex
+++ b/lib/prom_ex/metrics_server/plug.ex
@@ -26,7 +26,9 @@ defmodule PromEx.MetricsServer.Plug do
     case PromEx.get_metrics(prom_ex_module) do
       :prom_ex_down ->
         Logger.warn("Attempted to fetch metrics from #{prom_ex_module}, but the module has not been initialized")
+
         conn
+        |> send_resp(503, "Service Unavailable")
 
       metrics ->
         conn
@@ -71,6 +73,6 @@ defmodule PromEx.MetricsServer.Plug do
   def call(conn, _opts) do
     conn
     |> put_resp_content_type("text/plain")
-    |> send_resp(404, "Not found")
+    |> send_resp(404, "Not Found")
   end
 end

--- a/test/prom_ex/metrics_server/plug_test.exs
+++ b/test/prom_ex/metrics_server/plug_test.exs
@@ -1,9 +1,32 @@
 defmodule PromEx.MetricsServer.PlugTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   use Plug.Test
 
   alias Plug.Conn
   alias PromEx.MetricsServer
+
+  defmodule DefaultPromExSetUp do
+    use PromEx, otp_app: :prom_ex
+
+    alias PromEx.Plugins.Application
+
+    @impl true
+    def plugins do
+      [{Application, otp_app: :prom_ex}]
+    end
+
+    @impl true
+    def dashboards do
+      [{:prom_ex, "application.json"}]
+    end
+  end
+
+  setup_all do
+    System.put_env("APPLICATION_GIT_SHA", "395459c")
+    Application.put_env(:prom_ex, Test.Repo, telemetry_prefix: [:test, :repo])
+
+    []
+  end
 
   describe "init/1" do
     test "should separate the auth strategy from the remainder of the opts" do
@@ -17,44 +40,31 @@ defmodule PromEx.MetricsServer.PlugTest do
     end
   end
 
-  describe "call/2" do
-    test "should give a 404 if the request route does not match the configured route" do
-      opts =
-        MetricsServer.Plug.init(%{
-          path: "/metrics",
-          prom_ex_module: TestModule,
-          auth_strategy: :none
-        })
-
-      conn = conn(:get, "/bad-path")
-
-      assert %Conn{status: 404} = MetricsServer.Plug.call(conn, opts)
-    end
-
-    test "should return the metrics for a PromEx instance if no auth strategy is configured" do
-    end
-
-    test "should return the metrics for a PromEx instance if the bearer token is configured properly" do
-    end
+  describe "Basic auth" do
+    setup [:setup_basic_app_env, :setup_prom_ex_module]
 
     test "should return the metrics for a PromEx instance if the basic token is configured properly" do
-    end
-
-    test "should return a 401 if the request has an invalid bearer token" do
       opts =
         MetricsServer.Plug.init(%{
           path: "/metrics",
-          prom_ex_module: TestModule,
-          auth_strategy: :bearer,
-          auth_token: "abcd=="
+          prom_ex_module: DefaultPromExSetUp,
+          auth_strategy: :basic,
+          auth_user: "root",
+          auth_password: "toor"
         })
+
+      auth_header = Base.encode64("root:toor")
 
       conn =
         :get
         |> conn("/metrics")
-        |> put_req_header("authorization", "Bearer bad_token")
+        |> put_req_header("authorization", "Basic #{auth_header}")
 
-      assert %Conn{status: 401} = MetricsServer.Plug.call(conn, opts)
+      response = MetricsServer.Plug.call(conn, opts)
+
+      assert response.status == 200
+      assert response.resp_body =~ "prom_ex_application_primary_info"
+      assert response.resp_body =~ "395459c"
     end
 
     test "should return a 401 if the request has an invalid basic token" do
@@ -76,5 +86,111 @@ defmodule PromEx.MetricsServer.PlugTest do
 
       assert %Conn{status: 401} = MetricsServer.Plug.call(conn, opts)
     end
+  end
+
+  describe "Bearer auth" do
+    setup [:setup_bearer_app_env, :setup_prom_ex_module]
+
+    test "should return the metrics for a PromEx instance if the bearer token is configured properly" do
+      opts =
+        MetricsServer.Plug.init(%{
+          path: "/metrics",
+          prom_ex_module: DefaultPromExSetUp,
+          auth_strategy: :bearer,
+          auth_token: "abcd"
+        })
+
+      conn =
+        :get
+        |> conn("/metrics")
+        |> put_req_header("authorization", "Bearer abcd")
+
+      response = MetricsServer.Plug.call(conn, opts)
+
+      assert response.status == 200
+      assert response.resp_body =~ "prom_ex_application_primary_info"
+      assert response.resp_body =~ "395459c"
+    end
+
+    test "should return a 401 if the request has an invalid bearer token" do
+      opts =
+        MetricsServer.Plug.init(%{
+          path: "/metrics",
+          prom_ex_module: TestModule,
+          auth_strategy: :bearer,
+          auth_token: "abcd=="
+        })
+
+      conn =
+        :get
+        |> conn("/metrics")
+        |> put_req_header("authorization", "Bearer bad_token")
+
+      assert %Conn{status: 401} = MetricsServer.Plug.call(conn, opts)
+    end
+  end
+
+  describe "call/2" do
+    setup [:setup_none_app_env, :setup_prom_ex_module]
+
+    test "should return the metrics for a PromEx instance if no auth strategy is configured" do
+      opts =
+        MetricsServer.Plug.init(%{
+          path: "/metrics",
+          prom_ex_module: DefaultPromExSetUp,
+          auth_strategy: :none
+        })
+
+      conn = conn(:get, "/metrics")
+      response = MetricsServer.Plug.call(conn, opts)
+
+      assert response.status == 200
+      assert response.resp_body =~ "prom_ex_application_primary_info"
+      assert response.resp_body =~ "395459c"
+    end
+
+    test "should give a 404 if the request route does not match the configured route" do
+      opts =
+        MetricsServer.Plug.init(%{
+          path: "/metrics",
+          prom_ex_module: TestModule,
+          auth_strategy: :none
+        })
+
+      conn = conn(:get, "/bad-path")
+
+      assert %Conn{status: 404} = MetricsServer.Plug.call(conn, opts)
+    end
+  end
+
+  def setup_basic_app_env(context) do
+    set_up_app_env(port: 4422, auth_strategy: :basic, auth_user: "root", auth_password: "toor")
+
+    context
+  end
+
+  def setup_bearer_app_env(context) do
+    set_up_app_env(port: 4422, auth_strategy: :bearer, auth_token: "abcd")
+
+    context
+  end
+
+  def setup_none_app_env(context) do
+    set_up_app_env(port: 4422, auth_strategy: :none)
+
+    context
+  end
+
+  def set_up_app_env(opts) do
+    Application.put_env(:prom_ex, DefaultPromExSetUp, metrics_server: opts)
+  end
+
+  def setup_prom_ex_module(context) do
+    # Starting PromEx module and sleeping for a short while to give the applications plugin
+    # enough time to populate some metrics
+    start_supervised(DefaultPromExSetUp)
+    Process.sleep(500)
+
+    context
   end
 end

--- a/test/prom_ex/metrics_server/plug_test.exs
+++ b/test/prom_ex/metrics_server/plug_test.exs
@@ -1,0 +1,80 @@
+defmodule PromEx.MetricsServer.PlugTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Plug.Conn
+  alias PromEx.MetricsServer
+
+  describe "init/1" do
+    test "should separate the auth strategy from the remainder of the opts" do
+      opts = %{
+        path: "/metrics",
+        prom_ex_module: TestModule,
+        auth_strategy: :none
+      }
+
+      assert {:none, %{path: "/metrics", prom_ex_module: TestModule}} = MetricsServer.Plug.init(opts)
+    end
+  end
+
+  describe "call/2" do
+    test "should give a 404 if the request route does not match the configured route" do
+      opts =
+        MetricsServer.Plug.init(%{
+          path: "/metrics",
+          prom_ex_module: TestModule,
+          auth_strategy: :none
+        })
+
+      conn = conn(:get, "/bad-path")
+
+      assert %Conn{status: 404} = MetricsServer.Plug.call(conn, opts)
+    end
+
+    test "should return the metrics for a PromEx instance if no auth strategy is configured" do
+    end
+
+    test "should return the metrics for a PromEx instance if the bearer token is configured properly" do
+    end
+
+    test "should return the metrics for a PromEx instance if the basic token is configured properly" do
+    end
+
+    test "should return a 401 if the request has an invalid bearer token" do
+      opts =
+        MetricsServer.Plug.init(%{
+          path: "/metrics",
+          prom_ex_module: TestModule,
+          auth_strategy: :bearer,
+          auth_token: "abcd=="
+        })
+
+      conn =
+        :get
+        |> conn("/metrics")
+        |> put_req_header("authorization", "Bearer bad_token")
+
+      assert %Conn{status: 401} = MetricsServer.Plug.call(conn, opts)
+    end
+
+    test "should return a 401 if the request has an invalid basic token" do
+      opts =
+        MetricsServer.Plug.init(%{
+          path: "/metrics",
+          prom_ex_module: TestModule,
+          auth_strategy: :basic,
+          auth_user: "root",
+          auth_password: "toor"
+        })
+
+      auth_header = Base.encode64("admin:bad_pass")
+
+      conn =
+        :get
+        |> conn("/metrics")
+        |> put_req_header("authorization", "Basic #{auth_header}")
+
+      assert %Conn{status: 401} = MetricsServer.Plug.call(conn, opts)
+    end
+  end
+end


### PR DESCRIPTION
### Change description
Adding auth support to standalone metrics server.

### What problem does this solve?
Prometheus offers the ability to pass bearer and basic auth headers to the scrape source. This change will allow the standalone server to respect and check those headers if configured to do so. Auth support will only be implemented for the standalone server given that the Phoenix plug can leverage Unplug to do the same thing and can be catered to the specific needs of the user.

### Example usage

### Additional details and screenshots

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
