### PR TITLE
Use module.function capture for event handling

### DIFF
--- a/lib/core/counter.ex
+++ b/lib/core/counter.ex
@@ -25,7 +25,7 @@ defmodule PromEx.TelemetryMetricsPrometheus.Core.Counter do
            :telemetry.attach(
              handler_id,
              metric.event_name,
-             &handle_event/4,
+             &__MODULE__.handle_event/4,
              %{
                keep: metric.keep,
                metric_name: "",

--- a/lib/core/distribution.ex
+++ b/lib/core/distribution.ex
@@ -39,7 +39,7 @@ defmodule PromEx.TelemetryMetricsPrometheus.Core.Distribution do
            :telemetry.attach(
              handler_id,
              metric.event_name,
-             &handle_event/4,
+             &__MODULE__.handle_event/4,
              %{
                keep: metric.keep,
                measurement: metric.measurement,

--- a/lib/core/last_value.ex
+++ b/lib/core/last_value.ex
@@ -25,7 +25,7 @@ defmodule PromEx.TelemetryMetricsPrometheus.Core.LastValue do
            :telemetry.attach(
              handler_id,
              metric.event_name,
-             &handle_event/4,
+             &__MODULE__.handle_event/4,
              %{
                keep: metric.keep,
                measurement: metric.measurement,

--- a/lib/core/sum.ex
+++ b/lib/core/sum.ex
@@ -25,7 +25,7 @@ defmodule PromEx.TelemetryMetricsPrometheus.Core.Sum do
            :telemetry.attach(
              handler_id,
              metric.event_name,
-             &handle_event/4,
+             &__MODULE__.handle_event/4,
              %{
                keep: metric.keep,
                measurement: metric.measurement,

--- a/lib/prom_ex/debug.ex
+++ b/lib/prom_ex/debug.ex
@@ -25,12 +25,7 @@ defmodule PromEx.Debug do
     :telemetry.attach(
       random_id,
       event_name,
-      fn event_name, event_measurement, event_metadata, config ->
-        IO.inspect(event_name, label: "---- EVENT NAME ----", limit: :infinity, structs: false)
-        IO.inspect(event_measurement, label: "---- EVENT MEASUREMENT ----", limit: :infinity, structs: false)
-        IO.inspect(event_metadata, label: "---- EVENT METADATA ----", limit: :infinity, structs: false)
-        IO.inspect(config, label: "---- CONFIG ----", limit: :infinity, structs: false)
-      end,
+      &__MODULE__.handle_event/4,
       config
     )
 
@@ -52,15 +47,19 @@ defmodule PromEx.Debug do
     :telemetry.attach(
       random_id,
       event,
-      fn event_name, event_measurement, event_metadata, config ->
-        IO.inspect(event_name, label: "---- EVENT NAME ----", limit: :infinity, structs: false)
-        IO.inspect(event_measurement, label: "---- EVENT MEASUREMENT ----", limit: :infinity, structs: false)
-        IO.inspect(event_metadata, label: "---- EVENT METADATA ----", limit: :infinity, structs: false)
-        IO.inspect(config, label: "---- CONFIG ----", limit: :infinity, structs: false)
-      end,
+      &__MODULE__.handle_event/4,
       config
     )
 
     :ok
+  end
+
+  @doc false
+  @spec handle_event([atom], map, map, any) :: any
+  def handle_event(event_name, event_measurement, event_metadata, config) do
+    IO.inspect(event_name, label: "---- EVENT NAME ----", limit: :infinity, structs: false)
+    IO.inspect(event_measurement, label: "---- EVENT MEASUREMENT ----", limit: :infinity, structs: false)
+    IO.inspect(event_metadata, label: "---- EVENT METADATA ----", limit: :infinity, structs: false)
+    IO.inspect(config, label: "---- CONFIG ----", limit: :infinity, structs: false)
   end
 end

--- a/lib/prom_ex/plugins/ecto.ex
+++ b/lib/prom_ex/plugins/ecto.ex
@@ -68,6 +68,11 @@ if Code.ensure_loaded?(Ecto) do
       ]
     end
 
+    @doc false
+    def handle_event(_event_name, event_measurement, event_metadata, _config) do
+      :telemetry.execute(@query_event, event_measurement, event_metadata)
+    end
+
     # Generate the default telemetry prefix
     defp telemetry_prefix(repo) do
       repo
@@ -200,9 +205,7 @@ if Code.ensure_loaded?(Ecto) do
         :telemetry.attach(
           [:prom_ex, :ecto, :proxy] ++ telemetry_prefix,
           query_event,
-          fn _event_name, event_measurement, event_metadata, _config ->
-            :telemetry.execute(@query_event, event_measurement, event_metadata)
-          end,
+          &__MODULE__.handle_event/4,
           %{}
         )
       end)

--- a/lib/prom_ex/plugins/ecto.ex
+++ b/lib/prom_ex/plugins/ecto.ex
@@ -69,7 +69,7 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     @doc false
-    def handle_event(_event_name, event_measurement, event_metadata, _config) do
+    def handle_proxy_query_event(_event_name, event_measurement, event_metadata, _config) do
       :telemetry.execute(@query_event, event_measurement, event_metadata)
     end
 
@@ -205,7 +205,7 @@ if Code.ensure_loaded?(Ecto) do
         :telemetry.attach(
           [:prom_ex, :ecto, :proxy] ++ telemetry_prefix,
           query_event,
-          &__MODULE__.handle_event/4,
+          &__MODULE__.handle_proxy_query_event/4,
           %{}
         )
       end)

--- a/lib/prom_ex/plugins/oban.ex
+++ b/lib/prom_ex/plugins/oban.ex
@@ -145,7 +145,7 @@ if Code.ensure_loaded?(Oban) do
     end
 
     @doc false
-    def handle_event(_event_name, _event_measurement, event_metadata, _config) do
+    def handle_proxy_init_event(_event_name, _event_measurement, event_metadata, _config) do
       Enum.each(event_metadata.conf.queues, fn {queue, queue_opts} ->
         limit = Keyword.get(queue_opts, :limit, 0)
 
@@ -503,7 +503,7 @@ if Code.ensure_loaded?(Oban) do
       :telemetry.attach(
         [:prom_ex, :oban, :proxy] ++ prefix,
         @init_event,
-        &__MODULE__.handle_event/4,
+        &__MODULE__.handle_proxy_init_event/4,
         %{}
       )
     end

--- a/lib/prom_ex/plugins/oban.ex
+++ b/lib/prom_ex/plugins/oban.ex
@@ -144,6 +144,20 @@ if Code.ensure_loaded?(Oban) do
       )
     end
 
+    @doc false
+    def handle_event(_event_name, _event_measurement, event_metadata, _config) do
+      Enum.each(event_metadata.conf.queues, fn {queue, queue_opts} ->
+        limit = Keyword.get(queue_opts, :limit, 0)
+
+        metadata = %{
+          queue: queue,
+          name: event_metadata.conf.name
+        }
+
+        :telemetry.execute(@init_event_queue_limit_proxy, %{limit: limit}, metadata)
+      end)
+    end
+
     defp circuit_breaker_trip_tag_values(%{name: name, config: conf}) do
       %{
         name: normalize_module_name(conf.name),
@@ -489,18 +503,7 @@ if Code.ensure_loaded?(Oban) do
       :telemetry.attach(
         [:prom_ex, :oban, :proxy] ++ prefix,
         @init_event,
-        fn _event_name, _event_measurement, event_metadata, _config ->
-          Enum.each(event_metadata.conf.queues, fn {queue, queue_opts} ->
-            limit = Keyword.get(queue_opts, :limit, 0)
-
-            metadata = %{
-              queue: queue,
-              name: event_metadata.conf.name
-            }
-
-            :telemetry.execute(@init_event_queue_limit_proxy, %{limit: limit}, metadata)
-          end)
-        end,
+        &__MODULE__.handle_event/4,
         %{}
       )
     end


### PR DESCRIPTION
### Change description

Changed from local capture to module.function capture when using :telemetry.attach

I didn't run benchmarks on this, just following the guidance from the docs below.

### What problem does this solve?

> Note: due to how anonymous functions are implemented in the Erlang VM, it is best to use function captures (i.e. fun mod:fun/4 in Erlang or &Mod.fun/4 in Elixir) as event handlers to achieve maximum performance. In other words, avoid using literal anonymous functions (fun(...) -> ... end or fn ... -> ... end) or local function captures (fun handle_event/4 or &handle_event/4 ) as event handlers.

[Telemetry docs](https://hexdocs.pm/telemetry/)

Issue number: (if applicable)

### Example usage

### Additional details and screenshots

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
