### PR TITLE
Add normalize for Oban.Plugin with options

### DIFF
--- a/lib/prom_ex/plugins/oban.ex
+++ b/lib/prom_ex/plugins/oban.ex
@@ -514,6 +514,8 @@ if Code.ensure_loaded?(Oban) do
       |> String.trim_leading("Elixir.")
     end
 
+    defp normalize_module_name({name, _options}), do: normalize_module_name(name)
+
     defp normalize_module_name(name), do: name
   end
 else


### PR DESCRIPTION
### Change description
Add a case for `normalize_module_name` matching tuples which extracts the Plugin name from it.

### What problem does this solve?
See #34 

### Checklist

- [ ] I have added unit tests to cover my changes.
    - Since `normalize_module_name` is private and I am not sure how to test it: No
- [ ] I have added documentation to cover my changes.
    - No, since it's a private function
- [x] My changes have passed unit tests and have been tested E2E in an example project.
