### PR TITLE
Fix poller period

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Set up Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           elixir-version: '1.11.2'
           otp-version: '23.1'
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Set up Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}

--- a/lib/prom_ex.ex
+++ b/lib/prom_ex.ex
@@ -506,9 +506,7 @@ defmodule PromEx do
 
       {
         :telemetry_poller,
-        name: Module.concat([prom_ex_module, Poller, uniqe_poll_value]),
-        measurements: measurements,
-        period: poll_rate
+        name: Module.concat([prom_ex_module, Poller, uniqe_poll_value]), measurements: measurements, period: poll_rate
       }
     end)
   end

--- a/lib/prom_ex.ex
+++ b/lib/prom_ex.ex
@@ -508,7 +508,7 @@ defmodule PromEx do
         :telemetry_poller,
         name: Module.concat([prom_ex_module, Poller, uniqe_poll_value]),
         measurements: measurements,
-        poll_rate: poll_rate
+        period: poll_rate
       }
     end)
   end

--- a/test/prom_ex_test.exs
+++ b/test/prom_ex_test.exs
@@ -83,6 +83,12 @@ defmodule PromExTest do
       assert is_pid(poller_5000)
       refute is_pid(dashboard_uploader_pid)
 
+      # Ensure period is set correctly
+      poller_500_state = :sys.get_state(poller_500)
+      assert poller_500_state[:period] == 500
+      poller_5000_state = :sys.get_state(poller_5000)
+      assert poller_5000_state[:period] == 5000
+
       # Validate that the running processes have the correct names
       assert DefaultPromExSetUp.__manual_metrics_name__() == DefaultPromExSetUp.ManualMetricsManager
       assert DefaultPromExSetUp.__metrics_collector_name__() == DefaultPromExSetUp.Metrics


### PR DESCRIPTION
Telemetry poller expects :period instead of :poll_rate.

### Change description

### What problem does this solve?

Issue number: (if applicable)

### Example usage

### Additional details and screenshots

### Checklist

- [x] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
