### PR TITLE
[Fix] Include module dashboard assigns in export

### DIFF
--- a/lib/mix/tasks/prom_ex.dashboard.export.ex
+++ b/lib/mix/tasks/prom_ex.dashboard.export.ex
@@ -82,6 +82,8 @@ defmodule Mix.Tasks.PromEx.Dashboard.Export do
   end
 
   defp render_dashboard(prom_ex_module, cli_args) do
+    user_provided_assigns = prom_ex_module.dashboard_assigns()
+
     default_title =
       prom_ex_module.__otp_app__()
       |> Atom.to_string()
@@ -103,6 +105,7 @@ defmodule Mix.Tasks.PromEx.Dashboard.Export do
       :prom_ex
       |> DashboardRenderer.build(cli_args.dashboard)
       |> DashboardRenderer.merge_assigns(default_dashboard_assigns)
+      |> DashboardRenderer.merge_assigns(user_provided_assigns)
       |> DashboardRenderer.merge_assigns(cli_args.assigns)
       |> DashboardRenderer.render_dashboard()
       |> DashboardRenderer.decode_dashboard()


### PR DESCRIPTION
### Change description
Added the user configured assigns from the `PromEx` module to the rendering in `Mix.Tasks.PromEx.Dashboard.Export`.
I feel like there was an omission in the dashboard exporter, please correct me if that was wrong, but my thinking was that it's easiest to discuss with the proposed change.

Happy to discuss tests if required and change desired.

### What problem does this solve?
I setup my configuration as described in the docs, so that my `PromEx` default module was generated as expected.
When running the exporter (`Mix.Tasks.PromEx.Dashboard.Export`) for example like this:

```
mix prom_ex.dashboard.export --dashboard ecto.json --stdout  
```

I was expecting the assigns of the `PromEx` module to be used (it's the default module in my project and I checked that it was used). But those assigns are not actually used in the exporter, so warnings like this are shown:

```
warning: assign @datasource_id not available in EEx template. Please ensure all assigns are given as options. Available assigns: [:otp_app, :uid, :title]
```

In the uploader, the assigns of the module are actually taken into account, I would expect that to happen here as well.

### Example usage

Before, this was required: 
```
mix prom_ex.dashboard.export --dashboard ecto.json --stdout --assign datasource_id=MY_DATASOURCE_ID
```

Now it's simply:
```
mix prom_ex.dashboard.export --dashboard ecto.json --stdout
```

### Checklist

- [ ] I have added unit tests to cover my changes. (this task was not currently under tests)
- [ ] I have added documentation to cover my changes. (no documentation covering this at the moment)
- [x] My changes have passed unit tests and have been tested E2E in an example project. 
