### PR TITLE
Enable Grafana Basic Auth

### DIFF
--- a/lib/prom_ex/config.ex
+++ b/lib/prom_ex/config.ex
@@ -29,9 +29,9 @@ defmodule PromEx.Config do
   config :web_app, WebApp.PromEx,
     grafana: [
       host: "http://localhost:3000",
-      auth_username: "<YOUR_AUTH_USERNAME>",
-      auth_password: "<YOUR_AUTH_PASSWORD>"
-      auth_token: "<YOUR_AUTH_TOKEN_HERE>",
+      username: "<YOUR_USERNAME>",  # Or authenticate via Basic Auth
+      password: "<YOUR_PASSWORD>"
+      auth_token: "<YOUR_AUTH_TOKEN_HERE>", # Or authenticate via API Token
       upload_dashboards_on_start: true # This is an optional setting and will default to `true`
     ]
     ```
@@ -86,10 +86,10 @@ defmodule PromEx.Config do
       Grafana this valueshould be in the format `protocol://host:port` like `http://localhost:3000`
       for example.
 
-    * `:auth_username` - The auth username that was created in Grafana so that PromEx can upload dashboards
+    * `:username` - The username that was created in Grafana so that PromEx can upload dashboards
       via the API.
 
-    * `:auth_password` - The auth password that was created in Grafana so that PromEx can upload dashboards
+    * `:password` - The password that was created in Grafana so that PromEx can upload dashboards
       via the API.
 
     * `:auth_token` - The auth token that was created in Grafana so that PromEx can upload dashboards
@@ -200,8 +200,8 @@ defmodule PromEx.Config do
   defp generate_grafana_config(grafana_opts) do
     %{
       host: grafana_opts |> get_grafana_config(:host) |> normalize_host(),
-      auth_username: Keyword.get(grafana_opts, :auth_username),
-      auth_password: Keyword.get(grafana_opts, :auth_password),
+      username: Keyword.get(grafana_opts, :username),
+      password: Keyword.get(grafana_opts, :password),
       auth_token: Keyword.get(grafana_opts, :auth_token),
       upload_dashboards_on_start: Keyword.get(grafana_opts, :upload_dashboards_on_start, true),
       folder_name: Keyword.get(grafana_opts, :folder_name, :default),

--- a/lib/prom_ex/config.ex
+++ b/lib/prom_ex/config.ex
@@ -29,6 +29,8 @@ defmodule PromEx.Config do
   config :web_app, WebApp.PromEx,
     grafana: [
       host: "http://localhost:3000",
+      auth_username: "<YOUR_AUTH_USERNAME>",
+      auth_password: "<YOUR_AUTH_PASSWORD>"
       auth_token: "<YOUR_AUTH_TOKEN_HERE>",
       upload_dashboards_on_start: true # This is an optional setting and will default to `true`
     ]
@@ -83,6 +85,12 @@ defmodule PromEx.Config do
     * `:host` - The host address of your Grafana instance. In order for PromEx to communicate with
       Grafana this valueshould be in the format `protocol://host:port` like `http://localhost:3000`
       for example.
+
+    * `:auth_username` - The auth username that was created in Grafana so that PromEx can upload dashboards
+      via the API.
+
+    * `:auth_password` - The auth password that was created in Grafana so that PromEx can upload dashboards
+      via the API.
 
     * `:auth_token` - The auth token that was created in Grafana so that PromEx can upload dashboards
       via the API.
@@ -192,7 +200,9 @@ defmodule PromEx.Config do
   defp generate_grafana_config(grafana_opts) do
     %{
       host: grafana_opts |> get_grafana_config(:host) |> normalize_host(),
-      auth_token: get_grafana_config(grafana_opts, :auth_token),
+      auth_username: Keyword.get(grafana_opts, :auth_username),
+      auth_password: Keyword.get(grafana_opts, :auth_password),
+      auth_token: Keyword.get(grafana_opts, :auth_token),
       upload_dashboards_on_start: Keyword.get(grafana_opts, :upload_dashboards_on_start, true),
       folder_name: Keyword.get(grafana_opts, :folder_name, :default),
       annotate_app_lifecycle: Keyword.get(grafana_opts, :annotate_app_lifecycle, false)

--- a/lib/prom_ex/dashboard_uploader.ex
+++ b/lib/prom_ex/dashboard_uploader.ex
@@ -44,21 +44,15 @@ defmodule PromEx.DashboardUploader do
       default_dashboard_opts: default_dashboard_opts
     } = state
 
-    %PromEx.Config{
-      grafana_config: %{
-        host: grafana_host,
-        auth_token: grafana_auth_token,
-        folder_name: folder_name
-      }
-    } = prom_ex_module.init_opts()
+    %PromEx.Config{grafana_config: grafana_config} = prom_ex_module.init_opts()
 
     # Start Finch process and build Grafana connection
     finch_name = Module.concat([prom_ex_module, __MODULE__, Finch])
     Finch.start_link(name: finch_name)
-    grafana_conn = Connection.build(finch_name, grafana_host, grafana_auth_token)
+    grafana_conn = Connection.build(finch_name, grafana_config)
 
     upload_opts =
-      case folder_name do
+      case grafana_config.folder_name do
         :default ->
           []
 

--- a/lib/prom_ex/grafana_client.ex
+++ b/lib/prom_ex/grafana_client.ex
@@ -21,7 +21,7 @@ defmodule PromEx.GrafanaClient do
   @spec upload_dashboard(grafana_conn :: Connection.t(), dashboard_file_path :: String.t(), opts :: keyword()) ::
           handler_respose()
   def upload_dashboard(%Connection{} = grafana_conn, dashboard_contents, opts \\ []) do
-    headers = grafana_headers(:post, grafana_conn.auth_token)
+    headers = grafana_headers(:post, grafana_conn.authorization)
     payload = generate_payload(dashboard_contents, Keyword.merge(opts, overwrite: true))
 
     :post
@@ -36,7 +36,7 @@ defmodule PromEx.GrafanaClient do
   """
   @spec get_dashboard(grafana_conn :: Connection.t(), dashboard_file_path :: String.t()) :: handler_respose()
   def get_dashboard(%Connection{} = grafana_conn, dashboard_contents) do
-    headers = grafana_headers(:get, grafana_conn.auth_token)
+    headers = grafana_headers(:get, grafana_conn.authorization)
 
     dashboard_uid =
       dashboard_contents
@@ -55,7 +55,7 @@ defmodule PromEx.GrafanaClient do
   @spec create_folder(grafana_conn :: Connection.t(), folder_uid :: String.t(), title :: String.t()) ::
           handler_respose()
   def create_folder(%Connection{} = grafana_conn, folder_uid, title) do
-    headers = grafana_headers(:post, grafana_conn.auth_token)
+    headers = grafana_headers(:post, grafana_conn.authorization)
 
     payload =
       Jason.encode!(%{
@@ -75,7 +75,7 @@ defmodule PromEx.GrafanaClient do
   @spec update_folder(grafana_conn :: Connection.t(), folder_uid :: String.t(), new_title :: String.t()) ::
           handler_respose()
   def update_folder(%Connection{} = grafana_conn, folder_uid, new_title) do
-    headers = grafana_headers(:put, grafana_conn.auth_token)
+    headers = grafana_headers(:put, grafana_conn.authorization)
 
     payload =
       Jason.encode!(%{
@@ -94,7 +94,7 @@ defmodule PromEx.GrafanaClient do
   """
   @spec get_folder(grafana_conn :: Connection.t(), folder_uid :: String.t()) :: handler_respose()
   def get_folder(%Connection{} = grafana_conn, folder_id) do
-    headers = grafana_headers(:get, grafana_conn.auth_token)
+    headers = grafana_headers(:get, grafana_conn.authorization)
 
     :get
     |> Finch.build("#{grafana_conn.base_url}/api/folders/#{folder_id}", headers)
@@ -108,7 +108,7 @@ defmodule PromEx.GrafanaClient do
   @spec create_annotation(grafana_conn :: Connection.t(), tags :: [String.t()], message :: String.t()) ::
           handler_respose()
   def create_annotation(%Connection{} = grafana_conn, tags, message) do
-    headers = grafana_headers(:post, grafana_conn.auth_token)
+    headers = grafana_headers(:post, grafana_conn.authorization)
 
     payload =
       Jason.encode!(%{
@@ -144,16 +144,16 @@ defmodule PromEx.GrafanaClient do
     end
   end
 
-  defp grafana_headers(:get, bearer_token) do
+  defp grafana_headers(:get, authorization) do
     [
-      {"authorization", bearer_token},
+      {"authorization", authorization},
       {"accept", "application/json"}
     ]
   end
 
-  defp grafana_headers(action, bearer_token) when action in [:post, :put] do
+  defp grafana_headers(action, authorization) when action in [:post, :put] do
     [
-      {"authorization", bearer_token},
+      {"authorization", authorization},
       {"content-type", "application/json"},
       {"accept", "application/json"}
     ]

--- a/lib/prom_ex/grafana_client/connection.ex
+++ b/lib/prom_ex/grafana_client/connection.ex
@@ -16,7 +16,7 @@ defmodule PromEx.GrafanaClient.Connection do
   Build a connection struct for connecting to Grafana.
   """
   @spec build(finch_process :: module(), grafana_config :: map()) :: __MODULE__.t()
-  def build(finch_process, %{host: host, auth_username: username, auth_password: password}) do
+  def build(finch_process, %{host: host, username: username, password: password, auth_token: nil}) do
     %__MODULE__{
       finch_process: finch_process,
       base_url: normalize_host(host),

--- a/lib/prom_ex/grafana_client/connection.ex
+++ b/lib/prom_ex/grafana_client/connection.ex
@@ -7,20 +7,28 @@ defmodule PromEx.GrafanaClient.Connection do
   @type t :: %__MODULE__{
           finch_process: module(),
           base_url: String.t(),
-          auth_token: String.t()
+          authorization: String.t()
         }
 
-  defstruct finch_process: nil, base_url: nil, auth_token: nil
+  defstruct finch_process: nil, base_url: nil, authorization: nil
 
   @doc """
   Build a connection struct for connecting to Grafana.
   """
-  @spec build(finch_process :: module(), base_url :: String.t(), auth_token :: String.t()) :: __MODULE__.t()
-  def build(finch_process, base_url, auth_token) do
+  @spec build(finch_process :: module(), grafana_config :: map()) :: __MODULE__.t()
+  def build(finch_process, %{host: host, auth_username: username, auth_password: password}) do
     %__MODULE__{
       finch_process: finch_process,
-      base_url: normalize_host(base_url),
-      auth_token: "Bearer #{auth_token}"
+      base_url: normalize_host(host),
+      authorization: "Basic #{Base.encode64("#{username}:#{password}")}"
+    }
+  end
+
+  def build(finch_process, %{host: host, auth_token: auth_token}) do
+    %__MODULE__{
+      finch_process: finch_process,
+      base_url: normalize_host(host),
+      authorization: "Bearer #{auth_token}"
     }
   end
 

--- a/lib/prom_ex/lifecycle_annotator.ex
+++ b/lib/prom_ex/lifecycle_annotator.ex
@@ -78,17 +78,12 @@ defmodule PromEx.LifecycleAnnotator do
       |> Map.put(:git_author, git_author)
 
     # Get the Grafana config
-    %PromEx.Config{
-      grafana_config: %{
-        host: grafana_host,
-        auth_token: grafana_auth_token
-      }
-    } = prom_ex_module.init_opts()
+    %PromEx.Config{grafana_config: grafana_config} = prom_ex_module.init_opts()
 
     # Start Finch process and build Grafana connection
     finch_name = Module.concat([prom_ex_module, __MODULE__, Finch])
     Finch.start_link(name: finch_name)
-    grafana_conn = Connection.build(finch_name, grafana_host, grafana_auth_token)
+    grafana_conn = Connection.build(finch_name, grafana_config)
 
     annotation_details = generate_annotation_details(state)
     annotation_text = ["#{to_string(otp_app)} is starting up\n" | annotation_details] |> Enum.join("\n")
@@ -108,17 +103,12 @@ defmodule PromEx.LifecycleAnnotator do
 
   @impl true
   def terminate(_reason, %{prom_ex_module: prom_ex_module, otp_app: otp_app} = state) do
-    %PromEx.Config{
-      grafana_config: %{
-        host: grafana_host,
-        auth_token: grafana_auth_token
-      }
-    } = prom_ex_module.init_opts()
+    %PromEx.Config{grafana_config: grafana_config} = prom_ex_module.init_opts()
 
     # Start Finch process and build Grafana connection
     finch_name = Module.concat([prom_ex_module, __MODULE__, Finch])
     Finch.start_link(name: finch_name)
-    grafana_conn = Connection.build(finch_name, grafana_host, grafana_auth_token)
+    grafana_conn = Connection.build(finch_name, grafana_config)
 
     annotation_details = generate_annotation_details(state)
     annotation_text = ["#{to_string(otp_app)} is shutting down\n" | annotation_details] |> Enum.join("\n")

--- a/test/prom_ex/grafana_client/connection_test.exs
+++ b/test/prom_ex/grafana_client/connection_test.exs
@@ -4,14 +4,14 @@ defmodule PromEx.GrafanaClient.ConnectionTest do
   alias PromEx.GrafanaClient.Connection
 
   describe "build/1" do
-    test "should properly build a connection struct with provided host, auth_username, and auth_password values" do
+    test "should properly build a connection struct with provided host, username, and password values" do
       finch_name = PromEx.TestFinchName
       base_url = "http://localhost:3000"
       username = "admin"
       password = "1234567890"
 
       assert %Connection{finch_process: ^finch_name, base_url: ^base_url, authorization: authorization} =
-               Connection.build(finch_name, %{host: base_url, auth_username: username, auth_password: password})
+               Connection.build(finch_name, %{host: base_url, username: username, password: password, auth_token: nil})
 
       assert authorization == "Basic #{Base.encode64("#{username}:#{password}")}"
     end
@@ -25,7 +25,7 @@ defmodule PromEx.GrafanaClient.ConnectionTest do
                finch_process: ^finch_name,
                base_url: ^base_url,
                authorization: "Bearer " <> ^auth_token
-             } = Connection.build(finch_name, %{host: base_url, auth_token: auth_token})
+             } = Connection.build(finch_name, %{host: base_url, username: nil, password: nil, auth_token: auth_token})
     end
   end
 end

--- a/test/prom_ex/grafana_client/connection_test.exs
+++ b/test/prom_ex/grafana_client/connection_test.exs
@@ -4,7 +4,19 @@ defmodule PromEx.GrafanaClient.ConnectionTest do
   alias PromEx.GrafanaClient.Connection
 
   describe "build/1" do
-    test "should properly build a connection struct when values are provided" do
+    test "should properly build a connection struct with provided host, auth_username, and auth_password values" do
+      finch_name = PromEx.TestFinchName
+      base_url = "http://localhost:3000"
+      username = "admin"
+      password = "1234567890"
+
+      assert %Connection{finch_process: ^finch_name, base_url: ^base_url, authorization: authorization} =
+               Connection.build(finch_name, %{host: base_url, auth_username: username, auth_password: password})
+
+      assert authorization == "Basic #{Base.encode64("#{username}:#{password}")}"
+    end
+
+    test "should properly build a connection struct with provided host and auth_token values" do
       finch_name = PromEx.TestFinchName
       base_url = "http://localhost:3000"
       auth_token = "1234567890"
@@ -12,8 +24,8 @@ defmodule PromEx.GrafanaClient.ConnectionTest do
       assert %Connection{
                finch_process: ^finch_name,
                base_url: ^base_url,
-               auth_token: "Bearer " <> ^auth_token
-             } = Connection.build(finch_name, base_url, auth_token)
+               authorization: "Bearer " <> ^auth_token
+             } = Connection.build(finch_name, %{host: base_url, auth_token: auth_token})
     end
   end
 end


### PR DESCRIPTION
### Change description

Adds requested changes for feature request #45. I can add more tests and/or `PromEx.Config` grafana opts validation, but wanted to get feedback on if this is a desired direction first.

I originally was only going to do the following:

- Update `PromEx.Config` to make `auth_token` no longer required
- Update `PromEx.GrafanaClient.Connection` to only add `Bearer #{auth_token}` if `not is_nil(auth_token)`
- Update `PromEx.GrafanaClient` to only add `Bearer #{auth_token}` header if `not is_nil(auth_token)`

However, `Finch` removes any trace of Basic Auth from the url passed to `Finch.Request`. So I ended up having to add `:username` and `:password` values to the header manually via `Basic #{Base.encode64("#{username}:#{password}")}`

### What problem does this solve?

#45 

### Example usage

```elixir
config :vms, VMS.PromEx,
  grafana: [
    host: "http://localhost:3000",
    username: "admin",
    password: "admin"
  ]
```

### Additional details and screenshots

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
