### PR TITLE
Fix for responses with empty body

### DIFF
--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -93,7 +93,10 @@ if Code.ensure_loaded?(Phoenix) do
               buckets: exponential!(1, 4, 12)
             ],
             measurement: fn _measurements, metadata ->
-              :erlang.iolist_size(metadata.conn.resp_body)
+              case metadata.conn.resp_body do
+                nil -> 0
+                _ -> :erlang.iolist_size(metadata.conn.resp_body)
+              end
             end,
             tag_values: get_conn_tags(phoenix_router),
             tags: http_metrics_tags,


### PR DESCRIPTION
### Change description
`PromEx.Plugins.Phoenix` should return 0 as a measurment for `"http.response.size.bytes"` if the response body is empty.

### What problem does this solve?

In my app I have a plug that checks session value and redirects to root page if the user id is missing or the user has no access due to role.

I noticed an error in PromEx when such redirects occurred:

```
01:10:30.111 [error] Handler {PromEx.TelemetryMetricsPrometheus.Core.EventHandler, #PID<0.3719.0>, [:my_app, :prom_ex, :phoenix, :http, :response, :size, :bytes]} has failed and has been detach
ed. Class=:error
Reason=:badarg
Stacktrace=[{:erlang, :iolist_size, [nil], []}, {PromEx.Plugins.Phoenix, :"-http_events/2-fun-0-", 2, [file: 'lib/prom_ex/plugins/phoenix.ex', line: 96]}, {PromEx.TelemetryMetricsPrometheus.Core.Eve
ntHandler, :get_measurement, 3, [file: 'lib/core/event_handler.ex', line: 63]}, {PromEx.TelemetryMetricsPrometheus.Core.Distribution, :handle_event, 4, [file: 'lib/core/distribution.ex', line: 71]}, {:telemetry, :"-execute/3-fun-0-", 4, [
file: '/app/deps/telemetry/src/telemetry.erl', line: 135]}, {:lists, :foreach, 2, [file: 'lists.erl', line: 1342]}, {Plug.Telemetry, :"-call/2-fun-0-", 4, [file: 'lib/plug/telemetry.ex', line: 76]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3
, [file: 'lib/enum.ex', line: 2111]}]
```

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
