### PR TITLE
Fix typo in beam dashboard

### DIFF
--- a/priv/beam.json.eex
+++ b/priv/beam.json.eex
@@ -1131,7 +1131,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "<%= @datasource_id %>",
-      "description": "The number of garbage collection events that are occuring and the number of bytes reclaimed",
+      "description": "The number of garbage collection events that are occurring and the number of bytes reclaimed",
       "fieldConfig": {
         "defaults": {
           "custom": {},


### PR DESCRIPTION
### Change description

Updating a description in one of the BEAM dashboard's panels to remove a typo.

### Additional details and screenshots

I'm using PromEx now and can't use the grafana dashboard as-is (short of it is we need additional filters to get at the metrics and don't have the plugins you reference in our hosted grafana), but while porting the promex dashboard to my company's grafana models, I noticed the typo.

Teeny contribution, but hoping one of many.