### PR TITLE
Fix documentation for the --stdout flag

### DIFF
--- a/lib/mix/tasks/prom_ex.dashboard.export.ex
+++ b/lib/mix/tasks/prom_ex.dashboard.export.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.PromEx.Dashboard.Export do
                    This is needed to fetch any relevant assigns from the
                    `c:PromEx.dashboard_assigns/0` callback
 
-  -s, --std_out    A boolean flag denoting that the rendered dashboard should be output
+  -s, --stdout    A boolean flag denoting that the rendered dashboard should be output
                    to STDOUT.
 
   -f, --file_path  If you would like the write the generated JSON dashboard definition

--- a/test/mix/tasks/prom_ex.dashboard.export_test.exs
+++ b/test/mix/tasks/prom_ex.dashboard.export_test.exs
@@ -104,6 +104,19 @@ defmodule Mix.Tasks.PromEx.Dashboard.ExportTest do
     assert output =~ ~s("datasource": "an_id")
   end
 
+  test "outputs to STDOUT if the --stdout flag is present", ctx do
+    output =
+      capture_io(fn ->
+        File.cd!(ctx.tmp_dir, fn ->
+          Config.run(~w(-d an_id -o sample))
+          Code.compile_file("lib/sample/prom_ex.ex")
+          Export.run(~w(-m Sample.PromEx -d phoenix.json --stdout))
+        end)
+      end)
+
+    assert output =~ ~s("datasource": "an_id")
+  end
+
   test "outputs to STDOUT if the -s flag is present and there is an assign override", ctx do
     output =
       capture_io(fn ->


### PR DESCRIPTION
### Change description

The --stdout flag in the docs was incorrect (was `std_out`, but should be `stdout`). Fixed the docs and added a test for verification.

### What problem does this solve?

The use of the more verbose flag failed with a runtime exception saying the --std_out flag was invalid.

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
