### PR TITLE
Fix comments for the ecto results query

### DIFF
--- a/lib/prom_ex/plugins/ecto.ex
+++ b/lib/prom_ex/plugins/ecto.ex
@@ -182,7 +182,7 @@ if Code.ensure_loaded?(Ecto) do
             measurement: fn _measurement, %{result: result} ->
               normalize_results_returned(result)
             end,
-            description: "The time spent executing the query.",
+            description: "The number of result rows returned from a query.",
             tags: [:repo, :source, :command],
             tag_values: &ecto_query_tag_values/1,
             reporter_options: [


### PR DESCRIPTION
Update the description for the `ecto` plugin results returned query.

