### PR TITLE
Add an optional `metric_prefix` option to plugins

### DIFF
--- a/lib/mix/tasks/prom_ex.dashboard.export.ex
+++ b/lib/mix/tasks/prom_ex.dashboard.export.ex
@@ -69,12 +69,12 @@ defmodule Mix.Tasks.PromEx.Dashboard.Export do
         |> Enum.reduce(%{}, fn
           {:assign, assign_value}, acc when is_map_key(acc, :assigns) ->
             [key, value] = String.split(assign_value, "=", parts: 2)
-            new_assign = {String.to_existing_atom(key), value}
+            new_assign = {String.to_atom(key), value}
             Map.put(acc, :assigns, [new_assign | acc.assigns])
 
           {:assign, assign_value}, acc ->
             [key, value] = String.split(assign_value, "=", parts: 2)
-            Map.put(acc, :assigns, [{String.to_existing_atom(key), value}])
+            Map.put(acc, :assigns, [{String.to_atom(key), value}])
 
           {opt, value}, acc ->
             Map.put(acc, opt, value)

--- a/lib/prom_ex/dashboard_renderer.ex
+++ b/lib/prom_ex/dashboard_renderer.ex
@@ -44,7 +44,7 @@ defmodule PromEx.DashboardRenderer do
     base_def = %__MODULE__{
       otp_app: otp_app,
       relative_path: dashboard_relative_path,
-      assigns: []
+      assigns: default_plugin_assigns(otp_app)
     }
 
     dashboard_full_path =
@@ -150,5 +150,18 @@ defmodule PromEx.DashboardRenderer do
       {:error, reason} ->
         %{dashboard_render | valid_file?: false, full_path: path, error: {:file_read_error, reason}}
     end
+  end
+
+  defp default_plugin_assigns(otp_app) do
+    [
+      absinthe_metric_prefix: "#{otp_app}_prom_ex_absinthe",
+      application_metric_prefix: "#{otp_app}_prom_ex_application",
+      beam_metric_prefix: "#{otp_app}_prom_ex_beam",
+      ecto_metric_prefix: "#{otp_app}_prom_ex_ecto",
+      oban_metric_prefix: "#{otp_app}_prom_ex_oban",
+      phoenix_metric_prefix: "#{otp_app}_prom_ex_phoenix",
+      phoenix_live_view_metric_prefix: "#{otp_app}_prom_ex_phoenix_live_view",
+      prom_ex_metric_prefix: "#{otp_app}_prom_ex_prom_ex"
+    ]
   end
 end

--- a/lib/prom_ex/plugins/absinthe.ex
+++ b/lib/prom_ex/plugins/absinthe.ex
@@ -16,7 +16,9 @@ if Code.ensure_loaded?(Absinthe) do
       a value of `[:__schema]`. This is applicable to queries, mutations, and subscriptions.
 
     - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
-      `[otp_app, :prom_ex, :absinthe]`.
+      `[otp_app, :prom_ex, :absinthe]`. If this changes you will also want to set `absinthe_metric_prefix`
+      in your `dashboard_assigns` to the snakecase version of your prefix, the default
+      `absinthe_metric_prefix` is `{otp_app}_prom_ex_absinthe`.
 
     This plugin exposes the following metric groups:
     - `:absinthe_execute_event_metrics`

--- a/lib/prom_ex/plugins/absinthe.ex
+++ b/lib/prom_ex/plugins/absinthe.ex
@@ -15,6 +15,9 @@ if Code.ensure_loaded?(Absinthe) do
       metrics on the `:__schema` entrypoint (used for GraphQL schema introspection), you would set
       a value of `[:__schema]`. This is applicable to queries, mutations, and subscriptions.
 
+    - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
+      `[otp_app, :prom_ex, :absinthe]`.
+
     This plugin exposes the following metric groups:
     - `:absinthe_execute_event_metrics`
     - `:absinthe_subscription_event_metrics`
@@ -57,7 +60,7 @@ if Code.ensure_loaded?(Absinthe) do
     @impl true
     def event_metrics(opts) do
       otp_app = Keyword.fetch!(opts, :otp_app)
-      metric_prefix = PromEx.metric_prefix(otp_app, :absinthe)
+      metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :absinthe))
 
       # Event metrics definitions
       [

--- a/lib/prom_ex/plugins/application.ex
+++ b/lib/prom_ex/plugins/application.ex
@@ -19,6 +19,9 @@ defmodule PromEx.Plugins.Application do
     application's last Git commit author at the time of deployment. By default, an Application Plugin function
     will be called and will attempt to read the GIT_AUTHOR environment variable to populate the value.
 
+  - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
+    `[otp_app, :prom_ex, :application]`.
+
   This plugin exposes the following metric groups:
   - `:application_versions_manual_metrics`
 
@@ -55,7 +58,7 @@ defmodule PromEx.Plugins.Application do
     apps = Keyword.get(opts, :deps, :all)
     git_sha_mfa = Keyword.get(opts, :git_sha_mfa, {__MODULE__, :git_sha, []})
     git_author_mfa = Keyword.get(opts, :git_author_mfa, {__MODULE__, :git_author, []})
-    metric_prefix = PromEx.metric_prefix(otp_app, :application)
+    metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :application))
 
     [
       Manual.build(
@@ -106,7 +109,7 @@ defmodule PromEx.Plugins.Application do
   def polling_metrics(opts) do
     otp_app = Keyword.fetch!(opts, :otp_app)
     poll_rate = Keyword.get(opts, :poll_rate, 5_000)
-    metric_prefix = PromEx.metric_prefix(otp_app, :application)
+    metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :application))
 
     Polling.build(
       :application_time_polling_metrics,

--- a/lib/prom_ex/plugins/application.ex
+++ b/lib/prom_ex/plugins/application.ex
@@ -20,7 +20,9 @@ defmodule PromEx.Plugins.Application do
     will be called and will attempt to read the GIT_AUTHOR environment variable to populate the value.
 
   - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
-    `[otp_app, :prom_ex, :application]`.
+    `[otp_app, :prom_ex, :application]`. If this changes you will also want to set `application_metric_prefix`
+    in your `dashboard_assigns` to the snakecase version of your prefix, the default
+    `application_metric_prefix` is `{otp_app}_prom_ex_application`.
 
   This plugin exposes the following metric groups:
   - `:application_versions_manual_metrics`

--- a/lib/prom_ex/plugins/beam.ex
+++ b/lib/prom_ex/plugins/beam.ex
@@ -9,6 +9,9 @@ defmodule PromEx.Plugins.Beam do
   This plugin supports the following options:
   - `poll_rate`: This is option is OPTIONAL and is the rate at which poll metrics are refreshed (default is 5 seconds).
 
+  - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
+    `[otp_app, :prom_ex, :beam]`.
+
   This plugin exposes the following metric groups:
   - `:beam_memory_polling_metrics`
   - `:beam_internal_polling_metrics`
@@ -51,7 +54,7 @@ defmodule PromEx.Plugins.Beam do
   def polling_metrics(opts) do
     poll_rate = Keyword.get(opts, :poll_rate, 5_000)
     otp_app = Keyword.fetch!(opts, :otp_app)
-    metric_prefix = PromEx.metric_prefix(otp_app, :beam)
+    metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :beam))
 
     # TODO: Investigate Microstate accounting metrics
     # http://erlang.org/doc/man/erlang.html#statistics_microstate_accounting
@@ -71,7 +74,7 @@ defmodule PromEx.Plugins.Beam do
   @impl true
   def manual_metrics(opts) do
     otp_app = Keyword.fetch!(opts, :otp_app)
-    metric_prefix = PromEx.metric_prefix(otp_app, :beam)
+    metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :beam))
 
     [
       beam_cpu_topology_info(metric_prefix),

--- a/lib/prom_ex/plugins/beam.ex
+++ b/lib/prom_ex/plugins/beam.ex
@@ -10,7 +10,9 @@ defmodule PromEx.Plugins.Beam do
   - `poll_rate`: This is option is OPTIONAL and is the rate at which poll metrics are refreshed (default is 5 seconds).
 
   - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
-    `[otp_app, :prom_ex, :beam]`.
+    `[otp_app, :prom_ex, :beam]`. If this changes you will also want to set `beam_metric_prefix`
+    in your `dashboard_assigns` to the snakecase version of your prefix, the default
+    `beam_metric_prefix` is `{otp_app}_prom_ex_beam`.
 
   This plugin exposes the following metric groups:
   - `:beam_memory_polling_metrics`

--- a/lib/prom_ex/plugins/ecto.ex
+++ b/lib/prom_ex/plugins/ecto.ex
@@ -10,7 +10,9 @@ if Code.ensure_loaded?(Ecto) do
       default the otp_app set for the prom_ex module that this plugin is defined in is used.
 
     - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
-      `[otp_app, :prom_ex, :ecto]`.
+      `[otp_app, :prom_ex, :ecto]`. If this changes you will also want to set `ecto_metric_prefix`
+      in your `dashboard_assigns` to the snakecase version of your prefix, the default
+      `ecto_metric_prefix` is `{otp_app}_prom_ex_ecto`.
 
     - `repos`: This is an OPTIONAL option and is a list with the full module name of your Ecto Repos (e.g [MyApp.Repo]).
        If you do not provide this value, PromEx will attempt to resolve your Repo modules via the

--- a/lib/prom_ex/plugins/ecto.ex
+++ b/lib/prom_ex/plugins/ecto.ex
@@ -9,6 +9,9 @@ if Code.ensure_loaded?(Ecto) do
     - `otp_app`: This is an OPTIONAL option and is the name of you application in snake case (e.g. :my_cool_app). By
       default the otp_app set for the prom_ex module that this plugin is defined in is used.
 
+    - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
+      `[otp_app, :prom_ex, :ecto]`.
+
     - `repos`: This is an OPTIONAL option and is a list with the full module name of your Ecto Repos (e.g [MyApp.Repo]).
        If you do not provide this value, PromEx will attempt to resolve your Repo modules via the
        `:ecto_repos` configuration on your OTP app.
@@ -38,7 +41,7 @@ if Code.ensure_loaded?(Ecto) do
     @impl true
     def event_metrics(opts) do
       otp_app = Keyword.fetch!(opts, :otp_app)
-      metric_prefix = PromEx.metric_prefix(otp_app, :ecto)
+      metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :ecto))
 
       repo_event_prefixes =
         opts

--- a/lib/prom_ex/plugins/oban.ex
+++ b/lib/prom_ex/plugins/oban.ex
@@ -11,7 +11,9 @@ if Code.ensure_loaded?(Oban) do
       and only Oban instance has a different name, you can pass in your own list of Oban instances (e.g. `[Oban, Oban.PrivateJobs]`).
 
     - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
-      `[otp_app, :prom_ex, :oban]`.
+      `[otp_app, :prom_ex, :oban]`. If this changes you will also want to set `oban_metric_prefix`
+      in your `dashboard_assigns` to the snakecase version of your prefix, the default
+      `oban_metric_prefix` is `{otp_app}_prom_ex_oban`.
 
     - `poll_rate`: This option is OPTIONAL and is the rate at which poll metrics are refreshed (default is 5 seconds).
 

--- a/lib/prom_ex/plugins/oban.ex
+++ b/lib/prom_ex/plugins/oban.ex
@@ -10,6 +10,9 @@ if Code.ensure_loaded?(Oban) do
       default this option has a value of `[Oban]`. If you would like to track other named Oban instances, or perhaps your default
       and only Oban instance has a different name, you can pass in your own list of Oban instances (e.g. `[Oban, Oban.PrivateJobs]`).
 
+    - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
+      `[otp_app, :prom_ex, :oban]`.
+
     - `poll_rate`: This option is OPTIONAL and is the rate at which poll metrics are refreshed (default is 5 seconds).
 
     This plugin exposes the following metric groups:
@@ -62,7 +65,7 @@ if Code.ensure_loaded?(Oban) do
     @impl true
     def event_metrics(opts) do
       otp_app = Keyword.fetch!(opts, :otp_app)
-      metric_prefix = PromEx.metric_prefix(otp_app, :oban)
+      metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :oban))
 
       oban_supervisors = get_oban_supervisors(opts)
       keep_function_filter = keep_oban_instance_metrics(oban_supervisors)
@@ -81,7 +84,7 @@ if Code.ensure_loaded?(Oban) do
     @impl true
     def polling_metrics(opts) do
       otp_app = Keyword.fetch!(opts, :otp_app)
-      metric_prefix = PromEx.metric_prefix(otp_app, :oban)
+      metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :oban))
       poll_rate = Keyword.get(opts, :poll_rate, 5_000)
 
       oban_supervisors = get_oban_supervisors(opts)

--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -6,6 +6,10 @@ if Code.ensure_loaded?(Phoenix) do
 
     ## Plugin options
 
+    This plugin supports the following options:
+    - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
+      `[otp_app, :prom_ex, :phoenix]`.
+
     ### Single Endpoint/Router
     - `endpoint`: **Required** This is the full module name of your Phoenix Endpoint (e.g MyAppWeb.Endpoint).
     - `router`: **Required** This is the full module name of your Phoenix Router (e.g MyAppWeb.Router).
@@ -135,7 +139,7 @@ if Code.ensure_loaded?(Phoenix) do
     @impl true
     def event_metrics(opts) do
       otp_app = Keyword.fetch!(opts, :otp_app)
-      metric_prefix = PromEx.metric_prefix(otp_app, :phoenix)
+      metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :phoenix))
       phoenix_event_prefixes = fetch_event_prefixes!(opts)
 
       set_up_telemetry_proxy(phoenix_event_prefixes)

--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -8,7 +8,9 @@ if Code.ensure_loaded?(Phoenix) do
 
     This plugin supports the following options:
     - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
-      `[otp_app, :prom_ex, :phoenix]`.
+      `[otp_app, :prom_ex, :phoenix]`. If this changes you will also want to set `phoenix_metric_prefix`
+      in your `dashboard_assigns` to the snakecase version of your prefix, the default
+      `phoenix_metric_prefix` is `{otp_app}_prom_ex_phoenix`.
 
     ### Single Endpoint/Router
     - `endpoint`: **Required** This is the full module name of your Phoenix Endpoint (e.g MyAppWeb.Endpoint).

--- a/lib/prom_ex/plugins/phoenix_live_view.ex
+++ b/lib/prom_ex/plugins/phoenix_live_view.ex
@@ -6,7 +6,9 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     This plugin supports the following options:
     - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
-      `[otp_app, :prom_ex, :phoenix_live_view]`.
+      `[otp_app, :prom_ex, :phoenix_live_view]`. If this changes you will also want to set
+      `phoenix_live_view_metric_prefix` in your `dashboard_assigns` to the snakecase version of your
+      prefix, the default `phoenix_live_view_metric_prefix` is `{otp_app}_prom_ex_phoenix_live_view`.
 
     This plugin exposes the following metric groups:
     - `:phoenix_live_view_event_metrics`

--- a/lib/prom_ex/plugins/phoenix_live_view.ex
+++ b/lib/prom_ex/plugins/phoenix_live_view.ex
@@ -5,7 +5,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     mount, handle_event, and handle_params callbacks for live views and live components.
 
     This plugin supports the following options:
-    - This plugin does not currently support any additional options.
+    - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
+      `[otp_app, :prom_ex, :phoenix_live_view]`.
 
     This plugin exposes the following metric groups:
     - `:phoenix_live_view_event_metrics`
@@ -56,7 +57,7 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     @impl true
     def event_metrics(opts) do
       otp_app = Keyword.fetch!(opts, :otp_app)
-      metric_prefix = PromEx.metric_prefix(otp_app, :phoenix_live_view)
+      metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :phoenix_live_view))
 
       # Event metrics definitions
       [

--- a/lib/prom_ex/plugins/prom_ex.ex
+++ b/lib/prom_ex/plugins/prom_ex.ex
@@ -6,7 +6,7 @@ defmodule PromEx.Plugins.PromEx do
   @impl true
   def manual_metrics(opts) do
     otp_app = Keyword.fetch!(opts, :otp_app)
-    metric_prefix = PromEx.metric_prefix(otp_app, :prom_ex)
+    metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :prom_ex))
 
     Manual.build(
       :prom_ex_manual_metrics,

--- a/priv/absinthe.json.eex
+++ b/priv/absinthe.json.eex
@@ -109,7 +109,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "round(sum(increase(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", operation_type=\"query\", schema=\"$absinthe_schema\"}[24h])))",
+          "expr": "round(sum(increase(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", operation_type=\"query\", schema=\"$absinthe_schema\"}[24h])))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -167,7 +167,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "round(sum(increase(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", operation_type=\"mutation\", schema=\"$absinthe_schema\"}[24h])))",
+          "expr": "round(sum(increase(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", operation_type=\"mutation\", schema=\"$absinthe_schema\"}[24h])))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -228,7 +228,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "round(sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_complexity_size_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[24h])) / sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_complexity_size_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[24h])))",
+          "expr": "round(sum(rate(<%= @absinthe_metric_prefix %>_execute_complexity_size_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[24h])) / sum(rate(<%= @absinthe_metric_prefix %>_execute_complexity_size_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[24h])))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -289,7 +289,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "round(sum(increase(<%= @otp_app %>_prom_ex_absinthe_execute_invalid_request_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[24h])))",
+          "expr": "round(sum(increase(<%= @absinthe_metric_prefix %>_execute_invalid_request_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[24h])))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -347,7 +347,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "round(sum(increase(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", operation_type=\"query\", schema=\"$absinthe_schema\"}[1h])))",
+          "expr": "round(sum(increase(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", operation_type=\"query\", schema=\"$absinthe_schema\"}[1h])))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -405,7 +405,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "round(sum(increase(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", operation_type=\"mutation\", schema=\"$absinthe_schema\"}[1h])))",
+          "expr": "round(sum(increase(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", operation_type=\"mutation\", schema=\"$absinthe_schema\"}[1h])))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -466,7 +466,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "round(sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_complexity_size_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[1h])) / sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_complexity_size_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[1h])))",
+          "expr": "round(sum(rate(<%= @absinthe_metric_prefix %>_execute_complexity_size_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[1h])) / sum(rate(<%= @absinthe_metric_prefix %>_execute_complexity_size_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[1h])))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -527,7 +527,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "round(sum(increase(<%= @otp_app %>_prom_ex_absinthe_execute_invalid_request_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[1h])))",
+          "expr": "round(sum(increase(<%= @absinthe_metric_prefix %>_execute_invalid_request_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\"}[1h])))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -586,7 +586,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"query\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"query\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -668,7 +668,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"query\"}[$interval])) by(entrypoint) / sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"query\"}[$interval])) by(entrypoint)",
+          "expr": "sum(rate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"query\"}[$interval])) by(entrypoint) / sum(rate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"query\"}[$interval])) by(entrypoint)",
           "interval": "",
           "legendFormat": "{{ entrypoint }}",
           "refId": "A"
@@ -763,7 +763,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"query\"}[$interval])",
+          "expr": "rate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"query\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ entrypoint }}",
           "refId": "A"
@@ -858,7 +858,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_complexity_size_sum{job=\"$job\", instance=\"$instance\", operation_type=\"query\", schema=\"$absinthe_schema\"}[$interval])) by(entrypoint) / sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_complexity_size_count{job=\"$job\", instance=\"$instance\", operation_type=\"query\", schema=\"$absinthe_schema\"}[$interval])) by(entrypoint)",
+          "expr": "sum(rate(<%= @absinthe_metric_prefix %>_execute_complexity_size_sum{job=\"$job\", instance=\"$instance\", operation_type=\"query\", schema=\"$absinthe_schema\"}[$interval])) by(entrypoint) / sum(rate(<%= @absinthe_metric_prefix %>_execute_complexity_size_count{job=\"$job\", instance=\"$instance\", operation_type=\"query\", schema=\"$absinthe_schema\"}[$interval])) by(entrypoint)",
           "interval": "",
           "legendFormat": "{{ entrypoint }}",
           "refId": "A"
@@ -952,7 +952,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"mutation\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"mutation\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -1034,7 +1034,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"mutation\"}[$interval])) by(entrypoint) / sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"mutation\"}[$interval])) by(entrypoint)",
+          "expr": "sum(rate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"mutation\"}[$interval])) by(entrypoint) / sum(rate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"mutation\"}[$interval])) by(entrypoint)",
           "interval": "",
           "legendFormat": "{{ entrypoint }}",
           "refId": "A"
@@ -1129,7 +1129,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"mutation\"}[$interval])",
+          "expr": "rate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"mutation\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ entrypoint }}",
           "refId": "A"
@@ -1224,7 +1224,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_complexity_size_sum{job=\"$job\", instance=\"$instance\", operation_type=\"mutation\", schema=\"$absinthe_schema\"}[$interval])) by(entrypoint) / sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_complexity_size_count{job=\"$job\", instance=\"$instance\", operation_type=\"mutation\", schema=\"$absinthe_schema\"}[$interval])) by(entrypoint)",
+          "expr": "sum(rate(<%= @absinthe_metric_prefix %>_execute_complexity_size_sum{job=\"$job\", instance=\"$instance\", operation_type=\"mutation\", schema=\"$absinthe_schema\"}[$interval])) by(entrypoint) / sum(rate(<%= @absinthe_metric_prefix %>_execute_complexity_size_count{job=\"$job\", instance=\"$instance\", operation_type=\"mutation\", schema=\"$absinthe_schema\"}[$interval])) by(entrypoint)",
           "interval": "",
           "legendFormat": "{{ entrypoint }}",
           "refId": "A"
@@ -1318,7 +1318,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -1400,7 +1400,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by(entrypoint) / sum(rate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by(entrypoint)",
+          "expr": "sum(rate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by(entrypoint) / sum(rate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by(entrypoint)",
           "interval": "",
           "legendFormat": "{{ entrypoint }}",
           "refId": "A"
@@ -1495,7 +1495,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])",
+          "expr": "rate(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ entrypoint }}",
           "refId": "A"
@@ -1590,7 +1590,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(<%= @otp_app %>_prom_ex_absinthe_subscription_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by(entrypoint) / sum(rate(<%= @otp_app %>_prom_ex_absinthe_subscription_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by(entrypoint)",
+          "expr": "sum(rate(<%= @absinthe_metric_prefix %>_subscription_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by(entrypoint) / sum(rate(<%= @absinthe_metric_prefix %>_subscription_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", schema=\"$absinthe_schema\", operation_type=\"subscription\"}[$interval])) by(entrypoint)",
           "interval": "",
           "legendFormat": "{{ entrypoint }}",
           "refId": "A"
@@ -1647,7 +1647,7 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1657,7 +1657,7 @@
         "name": "job",
         "options": [],
         "query": {
-          "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+          "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1672,7 +1672,7 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1682,7 +1682,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+          "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1697,7 +1697,7 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count, schema)",
+        "definition": "label_values(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count, schema)",
         "description": "The Absinthe schema that handled the request",
         "error": null,
         "hide": 0,
@@ -1707,7 +1707,7 @@
         "name": "absinthe_schema",
         "options": [],
         "query": {
-          "query": "label_values(<%= @otp_app %>_prom_ex_absinthe_execute_duration_milliseconds_count, schema)",
+          "query": "label_values(<%= @absinthe_metric_prefix %>_execute_duration_milliseconds_count, schema)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/priv/application.json.eex
+++ b/priv/application.json.eex
@@ -94,7 +94,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_application_uptime_milliseconds_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @application_metric_prefix %>_uptime_milliseconds_count{job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -214,7 +214,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_application_dependency_info{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @application_metric_prefix %>_dependency_info{job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -299,7 +299,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_application_primary_info{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @application_metric_prefix %>_primary_info{job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -355,7 +355,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_application_git_sha_info{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @application_metric_prefix %>_git_sha_info{job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -411,7 +411,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_application_git_author_info{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @application_metric_prefix %>_git_author_info{job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -467,7 +467,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_application_primary_info{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @application_metric_prefix %>_primary_info{job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -523,7 +523,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_application_primary_info{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @application_metric_prefix %>_primary_info{job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -546,14 +546,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "hide": 0,
         "includeAll": false,
         "label": "Prometheus Job",
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -567,14 +567,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "Application Instance",
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/priv/beam.json.eex
+++ b/priv/beam.json.eex
@@ -108,7 +108,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_uptime_milliseconds_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_uptime_milliseconds_count{job=\"$job\", instance=\"$instance\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -188,7 +188,7 @@
                     "text": "SMP Support",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_smp_support_info"
+                    "value": "<%= @beam_metric_prefix %>_system_smp_support_info"
                   },
                   {
                     "from": "",
@@ -196,7 +196,7 @@
                     "text": "Thread Support",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_thread_support_info"
+                    "value": "<%= @beam_metric_prefix %>_system_thread_support_info"
                   },
                   {
                     "from": "",
@@ -204,7 +204,7 @@
                     "text": "Time Correction Support",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_time_correction_support_info"
+                    "value": "<%= @beam_metric_prefix %>_system_time_correction_support_info"
                   }
                 ]
               },
@@ -231,7 +231,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "{__name__=~\"<%= @otp_app %>_prom_ex_beam_system_thread_support_info|<%= @otp_app %>_prom_ex_beam_system_smp_support_info|<%= @otp_app %>_prom_ex_beam_system_time_correction_support_info\", job=\"$job\", instance=\"$instance\"}",
+          "expr": "{__name__=~\"<%= @beam_metric_prefix %>_system_thread_support_info|<%= @beam_metric_prefix %>_system_smp_support_info|<%= @beam_metric_prefix %>_system_time_correction_support_info\", job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -310,7 +310,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_system_version_info{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_system_version_info{job=\"$job\", instance=\"$instance\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -374,7 +374,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_process_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_process_count{job=\"$job\", instance=\"$instance\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -450,7 +450,7 @@
                     "text": "Dirty CPU Schedulers",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_dirty_cpu_schedulers_info"
+                    "value": "<%= @beam_metric_prefix %>_system_dirty_cpu_schedulers_info"
                   },
                   {
                     "from": "",
@@ -458,7 +458,7 @@
                     "text": "Dirty CPU Schedulers Online",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_dirty_cpu_schedulers_online_info"
+                    "value": "<%= @beam_metric_prefix %>_system_dirty_cpu_schedulers_online_info"
                   },
                   {
                     "from": "",
@@ -466,7 +466,7 @@
                     "text": "Dirty IO Schedulers",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_dirty_io_schedulers_info"
+                    "value": "<%= @beam_metric_prefix %>_system_dirty_io_schedulers_info"
                   },
                   {
                     "from": "",
@@ -474,7 +474,7 @@
                     "text": "System Schedulers",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_schedulers_info"
+                    "value": "<%= @beam_metric_prefix %>_system_schedulers_info"
                   },
                   {
                     "from": "",
@@ -482,7 +482,7 @@
                     "text": "System Schedulers Online",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_schedulers_online_info"
+                    "value": "<%= @beam_metric_prefix %>_system_schedulers_online_info"
                   },
                   {
                     "from": "",
@@ -490,7 +490,7 @@
                     "text": "Word Size in Bytes",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_word_size_bytes_info"
+                    "value": "<%= @beam_metric_prefix %>_system_word_size_bytes_info"
                   },
                   {
                     "from": "",
@@ -498,7 +498,7 @@
                     "text": "Logical Processors",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_logical_processors_info"
+                    "value": "<%= @beam_metric_prefix %>_system_logical_processors_info"
                   },
                   {
                     "from": "",
@@ -506,7 +506,7 @@
                     "text": "Logical Processors Available",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_logical_processors_available_info"
+                    "value": "<%= @beam_metric_prefix %>_system_logical_processors_available_info"
                   },
                   {
                     "from": "",
@@ -514,7 +514,7 @@
                     "text": "Logical Processors Online",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_logical_processors_online_info"
+                    "value": "<%= @beam_metric_prefix %>_system_logical_processors_online_info"
                   }
                 ]
               }
@@ -536,7 +536,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "{__name__=~\"<%= @otp_app %>_prom_ex_beam_system_dirty_cpu_schedulers_info|<%= @otp_app %>_prom_ex_beam_system_dirty_cpu_schedulers_online_info|<%= @otp_app %>_prom_ex_beam_system_dirty_io_schedulers_info|<%= @otp_app %>_prom_ex_beam_system_schedulers_info|<%= @otp_app %>_prom_ex_beam_system_schedulers_online_info|<%= @otp_app %>_prom_ex_beam_system_word_size_bytes_info|<%= @otp_app %>_prom_ex_beam_system_logical_processors_info|<%= @otp_app %>_prom_ex_beam_system_logical_processors_available_info|<%= @otp_app %>_prom_ex_beam_system_logical_processors_online_info\", job=\"$job\", instance=\"$instance\"}",
+          "expr": "{__name__=~\"<%= @beam_metric_prefix %>_system_dirty_cpu_schedulers_info|<%= @beam_metric_prefix %>_system_dirty_cpu_schedulers_online_info|<%= @beam_metric_prefix %>_system_dirty_io_schedulers_info|<%= @beam_metric_prefix %>_system_schedulers_info|<%= @beam_metric_prefix %>_system_schedulers_online_info|<%= @beam_metric_prefix %>_system_word_size_bytes_info|<%= @beam_metric_prefix %>_system_logical_processors_info|<%= @beam_metric_prefix %>_system_logical_processors_available_info|<%= @beam_metric_prefix %>_system_logical_processors_online_info\", job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -624,7 +624,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_port_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_port_count{job=\"$job\", instance=\"$instance\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -688,7 +688,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_ets_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_ets_count{job=\"$job\", instance=\"$instance\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -751,7 +751,7 @@
                     "text": "Atom Limit",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_atom_limit_info"
+                    "value": "<%= @beam_metric_prefix %>_system_atom_limit_info"
                   },
                   {
                     "from": "",
@@ -759,7 +759,7 @@
                     "text": "ETS Table Limit",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_ets_limit_info"
+                    "value": "<%= @beam_metric_prefix %>_system_ets_limit_info"
                   },
                   {
                     "from": "",
@@ -767,7 +767,7 @@
                     "text": "Port Limit",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_port_limit_info"
+                    "value": "<%= @beam_metric_prefix %>_system_port_limit_info"
                   },
                   {
                     "from": "",
@@ -775,7 +775,7 @@
                     "text": "Process Limit",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_beam_system_process_limit_info"
+                    "value": "<%= @beam_metric_prefix %>_system_process_limit_info"
                   },
                   {
                     "from": "",
@@ -805,7 +805,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "{__name__=~\"<%= @otp_app %>_prom_ex_beam_system_ets_limit_info|<%= @otp_app %>_prom_ex_beam_system_port_limit_info|<%= @otp_app %>_prom_ex_beam_system_process_limit_info|<%= @otp_app %>_prom_ex_beam_system_atom_limit_info\", job=\"$job\", instance=\"$instance\"}",
+          "expr": "{__name__=~\"<%= @beam_metric_prefix %>_system_ets_limit_info|<%= @beam_metric_prefix %>_system_port_limit_info|<%= @beam_metric_prefix %>_system_process_limit_info|<%= @beam_metric_prefix %>_system_atom_limit_info\", job=\"$job\", instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -893,7 +893,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_memory_allocated_bytes{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_memory_allocated_bytes{job=\"$job\", instance=\"$instance\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -957,7 +957,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_atom_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_atom_count{job=\"$job\", instance=\"$instance\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -1048,43 +1048,43 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_memory_allocated_bytes{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_memory_allocated_bytes{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Total Usage",
           "refId": "A"
         },
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_memory_atom_total_bytes{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_memory_atom_total_bytes{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Atoms",
           "refId": "B"
         },
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_memory_binary_total_bytes{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_memory_binary_total_bytes{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Binaries",
           "refId": "C"
         },
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_memory_code_total_bytes{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_memory_code_total_bytes{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Code",
           "refId": "D"
         },
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_memory_ets_total_bytes{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_memory_ets_total_bytes{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "ETS",
           "refId": "E"
         },
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_memory_processes_total_bytes{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_memory_processes_total_bytes{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Processes",
           "refId": "F"
         },
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_memory_persistent_term_total_bytes{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_memory_persistent_term_total_bytes{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Persistent Term",
           "refId": "G"
@@ -1206,13 +1206,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_beam_stats_gc_count{job=\"$job\", instance=\"$instance\"}[$interval])",
+          "expr": "irate(<%= @beam_metric_prefix %>_stats_gc_count{job=\"$job\", instance=\"$instance\"}[$interval])",
           "interval": "",
           "legendFormat": "Garbage Collections",
           "refId": "A"
         },
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_beam_stats_gc_reclaimed_bytes{job=\"$job\", instance=\"$instance\"}[$interval])",
+          "expr": "irate(<%= @beam_metric_prefix %>_stats_gc_reclaimed_bytes{job=\"$job\", instance=\"$instance\"}[$interval])",
           "instant": false,
           "interval": "",
           "legendFormat": "Bytes Reclaimed",
@@ -1326,13 +1326,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_active_task_count{job=\"$job\", instance=\"$instance\", type=\"normal\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_active_task_count{job=\"$job\", instance=\"$instance\", type=\"normal\"}",
           "interval": "",
           "legendFormat": "Normal Tasks",
           "refId": "A"
         },
         {
-          "expr": "0 - <%= @otp_app %>_prom_ex_beam_stats_run_queue_count{job=\"$job\", instance=\"$instance\", type=\"normal\"}",
+          "expr": "0 - <%= @beam_metric_prefix %>_stats_run_queue_count{job=\"$job\", instance=\"$instance\", type=\"normal\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "Normal Run Queue",
@@ -1446,13 +1446,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_active_task_count{job=\"$job\", instance=\"$instance\", type=\"dirty\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_active_task_count{job=\"$job\", instance=\"$instance\", type=\"dirty\"}",
           "interval": "",
           "legendFormat": "Dirty Tasks",
           "refId": "C"
         },
         {
-          "expr": "0 - <%= @otp_app %>_prom_ex_beam_stats_run_queue_count{job=\"$job\", instance=\"$instance\", type=\"dirty\"}",
+          "expr": "0 - <%= @beam_metric_prefix %>_stats_run_queue_count{job=\"$job\", instance=\"$instance\", type=\"dirty\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "Dirty Run Queue",
@@ -1575,13 +1575,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_beam_stats_reduction_count{job=\"$job\", instance=\"$instance\"}[$interval]) / 1000000",
+          "expr": "irate(<%= @beam_metric_prefix %>_stats_reduction_count{job=\"$job\", instance=\"$instance\"}[$interval]) / 1000000",
           "interval": "",
           "legendFormat": "Reductions",
           "refId": "A"
         },
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_beam_stats_context_switch_count{job=\"$job\", instance=\"$instance\"}[$interval])",
+          "expr": "irate(<%= @beam_metric_prefix %>_stats_context_switch_count{job=\"$job\", instance=\"$instance\"}[$interval])",
           "instant": false,
           "interval": "",
           "legendFormat": "Context Switches",
@@ -1693,7 +1693,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_process_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_process_count{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Active Processes",
           "refId": "A"
@@ -1805,7 +1805,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_atom_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_atom_count{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Active ports",
           "refId": "A"
@@ -1918,13 +1918,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "0 - irate(<%= @otp_app %>_prom_ex_beam_stats_port_io_byte_count{job=\"$job\", instance=\"$instance\", type=\"input\"}[$interval])",
+          "expr": "0 - irate(<%= @beam_metric_prefix %>_stats_port_io_byte_count{job=\"$job\", instance=\"$instance\", type=\"input\"}[$interval])",
           "interval": "",
           "legendFormat": "Data Received",
           "refId": "A"
         },
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_beam_stats_port_io_byte_count{job=\"$job\", instance=\"$instance\", type=\"output\"}[$interval])",
+          "expr": "irate(<%= @beam_metric_prefix %>_stats_port_io_byte_count{job=\"$job\", instance=\"$instance\", type=\"output\"}[$interval])",
           "interval": "",
           "legendFormat": "Data Sent",
           "refId": "B"
@@ -2035,7 +2035,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_ets_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_ets_count{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Active ETS Tables",
           "refId": "A"
@@ -2146,7 +2146,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_beam_stats_port_count{job=\"$job\", instance=\"$instance\"}",
+          "expr": "<%= @beam_metric_prefix %>_stats_port_count{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
           "legendFormat": "Active Ports",
           "refId": "A"
@@ -2203,14 +2203,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "hide": 0,
         "includeAll": false,
         "label": "Prometheus Job",
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -2224,14 +2224,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "Application Instance",
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/priv/ecto.json.eex
+++ b/priv/ecto.json.eex
@@ -107,7 +107,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_ecto_repo_query_idle_time_milliseconds_sum{instance=\"$instance\", job=\"$job\", repo=\"$repo\"} / <%= @otp_app %>_prom_ex_ecto_repo_query_idle_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}",
+          "expr": "<%= @ecto_metric_prefix %>_repo_query_idle_time_milliseconds_sum{instance=\"$instance\", job=\"$job\", repo=\"$repo\"} / <%= @ecto_metric_prefix %>_repo_query_idle_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -163,7 +163,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_ecto_repo_query_queue_time_milliseconds_sum{instance=\"$instance\", job=\"$job\", repo=\"$repo\"} / <%= @otp_app %>_prom_ex_ecto_repo_query_queue_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}",
+          "expr": "<%= @ecto_metric_prefix %>_repo_query_queue_time_milliseconds_sum{instance=\"$instance\", job=\"$job\", repo=\"$repo\"} / <%= @ecto_metric_prefix %>_repo_query_queue_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -219,7 +219,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_ecto_repo_query_decode_time_milliseconds_sum{instance=\"$instance\", job=\"$job\", repo=\"$repo\"} / <%= @otp_app %>_prom_ex_ecto_repo_query_decode_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}",
+          "expr": "<%= @ecto_metric_prefix %>_repo_query_decode_time_milliseconds_sum{instance=\"$instance\", job=\"$job\", repo=\"$repo\"} / <%= @ecto_metric_prefix %>_repo_query_decode_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -275,7 +275,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(<%= @otp_app %>_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}) / sum(<%= @otp_app %>_prom_ex_ecto_repo_query_execution_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"})",
+          "expr": "sum(<%= @ecto_metric_prefix %>_repo_query_execution_time_milliseconds_sum{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}) / sum(<%= @ecto_metric_prefix %>_repo_query_execution_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -331,7 +331,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_ecto_repo_init_status_info{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
+          "expr": "<%= @ecto_metric_prefix %>_repo_init_status_info{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -393,7 +393,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_ecto_repo_init_status_info{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
+          "expr": "<%= @ecto_metric_prefix %>_repo_init_status_info{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -455,7 +455,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_ecto_repo_init_status_info{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
+          "expr": "<%= @ecto_metric_prefix %>_repo_init_status_info{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -517,7 +517,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_ecto_repo_init_pool_size{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
+          "expr": "<%= @ecto_metric_prefix %>_repo_init_pool_size{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -579,7 +579,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_ecto_repo_init_timeout_duration{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
+          "expr": "<%= @ecto_metric_prefix %>_repo_init_timeout_duration{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -661,7 +661,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}[$interval])) by(command) / sum(irate(<%= @otp_app %>_prom_ex_ecto_repo_query_execution_time_milliseconds_count{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}[$interval])) by(command)",
+          "expr": "sum(irate(<%= @ecto_metric_prefix %>_repo_query_execution_time_milliseconds_sum{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}[$interval])) by(command) / sum(irate(<%= @ecto_metric_prefix %>_repo_query_execution_time_milliseconds_count{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}[$interval])) by(command)",
           "interval": "",
           "legendFormat": "{{ command }}",
           "refId": "A"
@@ -746,7 +746,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @ecto_metric_prefix %>_repo_query_execution_time_milliseconds_bucket{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -830,7 +830,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_ecto_repo_query_execution_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}[$interval])) by(source)",
+          "expr": "sum(increase(<%= @ecto_metric_prefix %>_repo_query_execution_time_milliseconds_count{instance=\"$instance\", job=\"$job\", repo=\"$repo\"}[$interval])) by(source)",
           "interval": "",
           "legendFormat": "{{ source }}",
           "refId": "A"
@@ -916,7 +916,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_ecto_repo_query_results_returned_bucket{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @ecto_metric_prefix %>_repo_query_results_returned_bucket{job=\"$job\", instance=\"$instance\", repo=\"$repo\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -960,14 +960,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "hide": 0,
         "includeAll": false,
         "label": "Prometheus Job",
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -981,14 +981,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "Application Instance",
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1002,14 +1002,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_ecto_repo_init_status_info, repo)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_repo_init_status_info, repo)",
         "hide": 0,
         "includeAll": false,
         "label": "Ecto Repo",
         "multi": false,
         "name": "repo",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_ecto_repo_init_status_info, repo)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_repo_init_status_info, repo)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/priv/oban.json.eex
+++ b/priv/oban.json.eex
@@ -101,7 +101,7 @@
                     "text": "Circuit Backoff",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_oban_init_circuit_backoff_milliseconds"
+                    "value": "<%= @oban_metric_prefix %>_init_circuit_backoff_milliseconds"
                   },
                   {
                     "from": "",
@@ -109,7 +109,7 @@
                     "text": "Cooldown",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_oban_init_dispatch_cooldown_milliseconds"
+                    "value": "<%= @oban_metric_prefix %>_init_dispatch_cooldown_milliseconds"
                   },
                   {
                     "from": "",
@@ -117,7 +117,7 @@
                     "text": "Global Poll Interval",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_oban_init_poll_interval_milliseconds"
+                    "value": "<%= @oban_metric_prefix %>_init_poll_interval_milliseconds"
                   },
                   {
                     "from": "",
@@ -125,7 +125,7 @@
                     "text": "Shutdown Grace Period",
                     "to": "",
                     "type": 1,
-                    "value": "<%= @otp_app %>_prom_ex_oban_init_shutdown_grace_period_milliseconds"
+                    "value": "<%= @oban_metric_prefix %>_init_shutdown_grace_period_milliseconds"
                   }
                 ]
               }
@@ -146,7 +146,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "{__name__=~\"<%= @otp_app %>_prom_ex_oban_init_circuit_backoff_milliseconds|<%= @otp_app %>_prom_ex_oban_init_shutdown_grace_period_milliseconds|<%= @otp_app %>_prom_ex_oban_init_poll_interval_milliseconds|<%= @otp_app %>_prom_ex_oban_init_dispatch_cooldown_milliseconds\", job=\"$job\", instance=\"$instance\", name=\"$oban\"}",
+          "expr": "{__name__=~\"<%= @oban_metric_prefix %>_init_circuit_backoff_milliseconds|<%= @oban_metric_prefix %>_init_shutdown_grace_period_milliseconds|<%= @oban_metric_prefix %>_init_poll_interval_milliseconds|<%= @oban_metric_prefix %>_init_dispatch_cooldown_milliseconds\", job=\"$job\", instance=\"$instance\", name=\"$oban\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -230,7 +230,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_oban_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"available\"}",
+          "expr": "<%= @oban_metric_prefix %>_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"available\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "{{ queue }}",
@@ -278,7 +278,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "{__name__=\"<%= @otp_app %>_prom_ex_oban_init_status_info\", job=\"$job\", instance=\"$instance\", name=\"$oban\"}",
+          "expr": "{__name__=\"<%= @oban_metric_prefix %>_init_status_info\", job=\"$job\", instance=\"$instance\", name=\"$oban\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -350,7 +350,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_oban_init_queue_concurrency_limit{instance=\"$instance\", job=\"$job\", name=\"$oban\"}",
+          "expr": "<%= @oban_metric_prefix %>_init_queue_concurrency_limit{instance=\"$instance\", job=\"$job\", name=\"$oban\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -427,7 +427,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_oban_job_processing_duration_milliseconds_count{instance=\"$instance\", job=\"$job\", name=\"$oban\"}[$interval]))",
+          "expr": "sum(increase(<%= @oban_metric_prefix %>_job_processing_duration_milliseconds_count{instance=\"$instance\", job=\"$job\", name=\"$oban\"}[$interval]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -483,7 +483,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_oban_job_exception_duration_milliseconds_count{instance=\"$instance\", job=\"$job\", name=\"$oban\"}[$interval]))",
+          "expr": "sum(increase(<%= @oban_metric_prefix %>_job_exception_duration_milliseconds_count{instance=\"$instance\", job=\"$job\", name=\"$oban\"}[$interval]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -539,7 +539,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_oban_producer_dispatched_count_count{instance=\"$instance\", job=\"$job\", name=\"$oban\"}[$interval]))",
+          "expr": "sum(increase(<%= @oban_metric_prefix %>_producer_dispatched_count_count{instance=\"$instance\", job=\"$job\", name=\"$oban\"}[$interval]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -602,7 +602,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_oban_job_processing_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @oban_metric_prefix %>_job_processing_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -674,7 +674,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_oban_job_queue_time_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @oban_metric_prefix %>_job_queue_time_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -758,7 +758,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_oban_job_processing_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @otp_app %>_prom_ex_oban_job_processing_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "irate(<%= @oban_metric_prefix %>_job_processing_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @oban_metric_prefix %>_job_processing_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "({{ state }}) {{ name }} :: {{ worker }}",
           "refId": "A"
@@ -855,7 +855,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_oban_job_queue_time_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @otp_app %>_prom_ex_oban_job_queue_time_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "irate(<%= @oban_metric_prefix %>_job_queue_time_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @oban_metric_prefix %>_job_queue_time_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "({{ state }}) {{ name }} :: {{ worker }}",
           "refId": "A"
@@ -952,7 +952,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_oban_job_complete_attempts_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @otp_app %>_prom_ex_oban_job_complete_attempts_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "irate(<%= @oban_metric_prefix %>_job_complete_attempts_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @oban_metric_prefix %>_job_complete_attempts_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "({{ state }}) {{ name }} :: {{ worker }}",
           "refId": "A"
@@ -1051,7 +1051,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_oban_job_exception_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @oban_metric_prefix %>_job_exception_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -1123,7 +1123,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_oban_job_exception_queue_time_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @oban_metric_prefix %>_job_exception_queue_time_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -1207,7 +1207,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_oban_job_exception_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @otp_app %>_prom_ex_oban_job_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "irate(<%= @oban_metric_prefix %>_job_exception_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @oban_metric_prefix %>_job_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "({{ error }}) {{ name }} :: {{ worker }}",
           "refId": "A"
@@ -1304,7 +1304,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_oban_job_exception_queue_time_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @otp_app %>_prom_ex_oban_job_exception_queue_time_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "irate(<%= @oban_metric_prefix %>_job_exception_queue_time_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @oban_metric_prefix %>_job_exception_queue_time_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "({{ error }}) {{ name }} :: {{ worker }}",
           "refId": "A"
@@ -1401,7 +1401,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_oban_job_exception_attempts_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @otp_app %>_prom_ex_oban_job_exception_attempts_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "irate(<%= @oban_metric_prefix %>_job_exception_attempts_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @oban_metric_prefix %>_job_exception_attempts_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "({{ state }}) {{ name }} :: {{ worker }}",
           "refId": "A"
@@ -1510,7 +1510,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_oban_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"available\"}",
+          "expr": "<%= @oban_metric_prefix %>_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"available\"}",
           "interval": "",
           "legendFormat": "{{ queue }}",
           "refId": "A"
@@ -1605,7 +1605,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_oban_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"completed\"}",
+          "expr": "<%= @oban_metric_prefix %>_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"completed\"}",
           "interval": "",
           "legendFormat": "{{ queue }}",
           "refId": "A"
@@ -1700,7 +1700,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_oban_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"executing\"}",
+          "expr": "<%= @oban_metric_prefix %>_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"executing\"}",
           "interval": "",
           "legendFormat": "{{ queue }}",
           "refId": "A"
@@ -1795,7 +1795,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_oban_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"retryable\"}",
+          "expr": "<%= @oban_metric_prefix %>_queue_length_count{job=\"$job\", instance=\"$instance\", name=\"$oban\", state=\"retryable\"}",
           "interval": "",
           "legendFormat": "{{ queue }}",
           "refId": "A"
@@ -1894,7 +1894,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_oban_producer_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @oban_metric_prefix %>_producer_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -1966,7 +1966,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_oban_producer_dispatched_count_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @oban_metric_prefix %>_producer_dispatched_count_bucket{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -2046,7 +2046,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_oban_producer_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @otp_app %>_prom_ex_oban_producer_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "irate(<%= @oban_metric_prefix %>_producer_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @oban_metric_prefix %>_producer_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ queue }}",
           "refId": "A"
@@ -2139,7 +2139,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_oban_producer_dispatched_count_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @otp_app %>_prom_ex_oban_producer_dispatched_count_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "irate(<%= @oban_metric_prefix %>_producer_dispatched_count_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @oban_metric_prefix %>_producer_dispatched_count_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ queue }}",
           "refId": "A"
@@ -2232,7 +2232,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_oban_producer_exception_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @otp_app %>_prom_ex_oban_producer_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "irate(<%= @oban_metric_prefix %>_producer_exception_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval]) / irate(<%= @oban_metric_prefix %>_producer_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ queue }}",
           "refId": "A"
@@ -2342,7 +2342,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "increase(<%= @otp_app %>_prom_ex_oban_circuit_trip_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[1h])",
+          "expr": "increase(<%= @oban_metric_prefix %>_circuit_trip_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[1h])",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2402,7 +2402,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_oban_circuit_trip_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}",
+          "expr": "<%= @oban_metric_prefix %>_circuit_trip_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2462,7 +2462,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "increase(<%= @otp_app %>_prom_ex_oban_circuit_open_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[1h])",
+          "expr": "increase(<%= @oban_metric_prefix %>_circuit_open_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[1h])",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2522,7 +2522,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "<%= @otp_app %>_prom_ex_oban_circuit_open_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}",
+          "expr": "<%= @oban_metric_prefix %>_circuit_open_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2579,7 +2579,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(<%= @otp_app %>_prom_ex_oban_circuit_trip_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "increase(<%= @oban_metric_prefix %>_circuit_trip_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ circuit_breaker }}",
           "refId": "A"
@@ -2672,7 +2672,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(<%= @otp_app %>_prom_ex_oban_circuit_open_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
+          "expr": "increase(<%= @oban_metric_prefix %>_circuit_open_total{job=\"$job\", instance=\"$instance\", name=\"$oban\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ circuit_breaker }}",
           "refId": "A"
@@ -2734,14 +2734,14 @@
           "value": "elixir_app"
         },
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "hide": 0,
         "includeAll": false,
         "label": "Prometheus Job",
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -2760,14 +2760,14 @@
           "value": "elixir_app_one:4000"
         },
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "Application Instance",
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -2781,14 +2781,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_oban_init_status_info, name)",
+        "definition": "label_values(<%= @oban_metric_prefix %>_init_status_info, name)",
         "hide": 0,
         "includeAll": false,
         "label": "Oban Instance",
         "multi": false,
         "name": "oban",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_oban_init_status_info, name)",
+        "query": "label_values(<%= @oban_metric_prefix %>_init_status_info, name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/priv/phoenix.json.eex
+++ b/priv/phoenix.json.eex
@@ -115,7 +115,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "(\n  (\n    sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[24h])) + \n    (sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"1024\", status=~\"2..\"}[24h])) - sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[24h]))) / 2\n  ) \n  / \n  sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", status=~\"2..\"}[24h]))\n) * 100",
+          "expr": "(\n  (\n    sum(increase(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[24h])) + \n    (sum(increase(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"1024\", status=~\"2..\"}[24h])) - sum(increase(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[24h]))) / 2\n  ) \n  / \n  sum(increase(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", status=~\"2..\"}[24h]))\n) * 100",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -179,7 +179,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[24h])) / sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{job=\"$job\", instance=\"$instance\"}[24h])) OR on() vector(0)",
+          "expr": "sum(increase(<%= @phoenix_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[24h])) / sum(increase(<%= @phoenix_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[24h])) OR on() vector(0)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -235,7 +235,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[24h]))",
+          "expr": "sum(increase(<%= @phoenix_metric_prefix %>_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[24h]))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -291,7 +291,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{job=\"$job\", instance=\"$instance\"}[24h]))",
+          "expr": "sum(increase(<%= @phoenix_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[24h]))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -356,7 +356,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "(\n  (\n    sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[1h])) + \n    (sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"1024\", status=~\"2..\"}[1h])) - sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[1h]))) / 2\n  ) \n  / \n  sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", status=~\"2..\"}[1h]))\n) * 100",
+          "expr": "(\n  (\n    sum(increase(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[1h])) + \n    (sum(increase(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"1024\", status=~\"2..\"}[1h])) - sum(increase(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[1h]))) / 2\n  ) \n  / \n  sum(increase(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", status=~\"2..\"}[1h]))\n) * 100",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -421,7 +421,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[1h])) / sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{job=\"$job\", instance=\"$instance\"}[1h])) OR on() vector(0)",
+          "expr": "sum(increase(<%= @phoenix_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[1h])) / sum(increase(<%= @phoenix_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[1h])) OR on() vector(0)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -477,7 +477,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[1h]))",
+          "expr": "sum(increase(<%= @phoenix_metric_prefix %>_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[1h]))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -533,7 +533,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{job=\"$job\", instance=\"$instance\"}[1h]))",
+          "expr": "sum(increase(<%= @phoenix_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[1h]))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -597,7 +597,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -669,7 +669,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_http_response_size_bytes_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @phoenix_metric_prefix %>_http_response_size_bytes_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -753,7 +753,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status) / sum(irate(<%= @otp_app %>_prom_ex_phoenix_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status)",
+          "expr": "sum(irate(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status) / sum(irate(<%= @phoenix_metric_prefix %>_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status)",
           "interval": "",
           "legendFormat": "{{ method }} {{ path }} :: {{ status }}",
           "refId": "A"
@@ -850,7 +850,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status) / sum(irate(<%= @otp_app %>_prom_ex_phoenix_http_response_size_bytes_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status)",
+          "expr": "sum(irate(<%= @phoenix_metric_prefix %>_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status) / sum(irate(<%= @phoenix_metric_prefix %>_http_response_size_bytes_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status)",
           "interval": "",
           "legendFormat": "{{ method }} {{ path }} :: {{ status }}",
           "refId": "A"
@@ -947,7 +947,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{job=\"$job\", instance=\"$instance\"}[$interval])",
+          "expr": "irate(<%= @phoenix_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ method }} {{ path }} :: {{ status }}",
           "refId": "A"
@@ -1042,19 +1042,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{status=~\"2..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
+          "expr": "sum(irate(<%= @phoenix_metric_prefix %>_http_requests_total{status=~\"2..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
           "interval": "",
           "legendFormat": "2xx",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{status=~\"4..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
+          "expr": "sum(irate(<%= @phoenix_metric_prefix %>_http_requests_total{status=~\"4..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
           "interval": "",
           "legendFormat": "4xx",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_http_requests_total{status=~\"5..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
+          "expr": "sum(irate(<%= @phoenix_metric_prefix %>_http_requests_total{status=~\"5..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
           "interval": "",
           "legendFormat": "5xx",
           "refId": "C"
@@ -1163,7 +1163,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_phoenix_channel_joined_total{job=\"$job\", instance=\"$instance\"}[$interval])",
+          "expr": "irate(<%= @phoenix_metric_prefix %>_channel_joined_total{job=\"$job\", instance=\"$instance\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ transport }} :: {{ result }}",
           "refId": "A"
@@ -1248,7 +1248,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @phoenix_metric_prefix %>_channel_handled_in_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -1332,7 +1332,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_channel_handled_in_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path) / sum(irate(<%= @otp_app %>_prom_ex_phoenix_channel_handled_in_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path)",
+          "expr": "sum(irate(<%= @phoenix_metric_prefix %>_channel_handled_in_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path) / sum(irate(<%= @phoenix_metric_prefix %>_channel_handled_in_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1389,14 +1389,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "hide": 0,
         "includeAll": false,
         "label": "Prometheus Job",
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1410,14 +1410,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "Application Instance",
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/priv/phoenix_live_view.json.eex
+++ b/priv/phoenix_live_view.json.eex
@@ -116,7 +116,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) / \n(\n  sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) + \n  (sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0))\n)",
+          "expr": "sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) / \n(\n  sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) + \n  (sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0))\n)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -173,7 +173,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "(sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0)) + (sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0))",
+          "expr": "(sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0)) + (sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -238,7 +238,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) / \n(\n  sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) + \n  (sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0))\n)",
+          "expr": "sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) / \n(\n  sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) + \n  (sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0))\n)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -295,7 +295,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "(sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0)) + (sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0))",
+          "expr": "(sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0)) + (sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[24h])) or vector(0))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -360,7 +360,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) / \n(\n  sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) + \n  (sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0))\n)",
+          "expr": "sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) / \n(\n  sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) + \n  (sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0))\n)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -417,7 +417,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "(sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0)) + (sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0))",
+          "expr": "(sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0)) + (sum(increase(<%= @phoenix_live_view_metric_prefix %>_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -482,7 +482,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) / \n(\n  sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) + \n  (sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0))\n)",
+          "expr": "sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) / \n(\n  sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) + \n  (sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0))\n)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -539,7 +539,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "(sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0)) + (sum(increase(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0))",
+          "expr": "(sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0)) + (sum(increase(<%= @phoenix_live_view_metric_prefix %>_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[1h])) or vector(0))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -615,7 +615,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module) / sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module)",
+          "expr": "sum(irate(<%= @phoenix_live_view_metric_prefix %>_mount_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module) / sum(irate(<%= @phoenix_live_view_metric_prefix %>_mount_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module)",
           "instant": false,
           "interval": "",
           "legendFormat": "({{ action }}) {{ module }}",
@@ -713,7 +713,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_exception_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module, kind, reason) / sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module, kind, reason)",
+          "expr": "sum(irate(<%= @phoenix_live_view_metric_prefix %>_mount_exception_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module, kind, reason) / sum(irate(<%= @phoenix_live_view_metric_prefix %>_mount_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module, kind, reason)",
           "instant": false,
           "interval": "",
           "legendFormat": "({{ action }}) {{ module }} :: ({{kind}} -> {{reason}})",
@@ -799,7 +799,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @phoenix_live_view_metric_prefix %>_mount_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -871,7 +871,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_mount_exception_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @phoenix_live_view_metric_prefix %>_mount_exception_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -969,7 +969,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module, event) / sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module, event)",
+          "expr": "sum(irate(<%= @phoenix_live_view_metric_prefix %>_handle_event_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module, event) / sum(irate(<%= @phoenix_live_view_metric_prefix %>_handle_event_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(action, module, event)",
           "instant": false,
           "interval": "",
           "legendFormat": "({{ action }}) {{ module }} :: {{ event }}",
@@ -1067,7 +1067,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_exception_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(event, action, module, kind, reason) / sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(event, action, module, kind, reason)",
+          "expr": "sum(irate(<%= @phoenix_live_view_metric_prefix %>_handle_event_exception_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(event, action, module, kind, reason) / sum(irate(<%= @phoenix_live_view_metric_prefix %>_handle_event_exception_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(event, action, module, kind, reason)",
           "instant": false,
           "interval": "",
           "legendFormat": "({{ action }}) {{ module }} :: {{event}} ({{kind}} -> {{reason}})",
@@ -1153,7 +1153,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @phoenix_live_view_metric_prefix %>_handle_event_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -1225,7 +1225,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_phoenix_live_view_handle_event_exception_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @phoenix_live_view_metric_prefix %>_handle_event_exception_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -1269,14 +1269,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "hide": 0,
         "includeAll": false,
         "label": "Prometheus Job",
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1290,14 +1290,14 @@
       {
         "allValue": null,
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "definition": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "Application Instance",
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "query": "label_values(<%= @prom_ex_metric_prefix %>_status_info, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/test/mix/tasks/prom_ex.dashboard.export_test.exs
+++ b/test/mix/tasks/prom_ex.dashboard.export_test.exs
@@ -148,7 +148,7 @@ defmodule Mix.Tasks.PromEx.Dashboard.ExportTest do
         File.cd!(ctx.tmp_dir, fn ->
           Config.run(~w(-d an_id -o sample))
           Code.compile_file("lib/sample/prom_ex.ex")
-          Export.run(~w(-m Sample.PromEx -d phoenix.json -s -a datasource_id=another_id -a otp_app=another_app))
+          Export.run(~w(-m Sample.PromEx -d phoenix.json -s -a datasource_id=another_id -a prom_ex_metric_prefix=another_app_prom_ex_prom_ex))
         end)
       end)
 


### PR DESCRIPTION
### Change description

Allow overriding the `PromEx.metric_prefix/2` from `plugins/0` configuration.

### What problem does this solve?

As a consultancy, we have many applications and want to make a more generic set of dashboards. To do this we need applications outputting the same set of metric names. With this, we can let `prom_ex_#{plugin}` be the lead of the metric and not have the specific application in place.

Issue number: (if applicable)

### Example usage

```
  def plugins() do
    [
      {Plugins.Application, metric_prefix: [:prom_ex, :application]},
      {Plugins.Beam, metric_prefix: [:prom_ex, :beam]},
      {Plugins.Phoenix, metric_prefix: [:prom_ex, :phoenix], router: Web.Router},
      {Plugins.Ecto, metric_prefix: [:prom_ex, :ecto]},
      {Plugins.Oban, metric_prefix: [:prom_ex, :oban], oban_supervisors: [Oban]},
      {Plugins.PromEx, metric_prefix: [:prom_ex, :prom_ex]}
    ]
  end
```

### Additional details and screenshots

We also tag each job with the environment and product / client that we're scraping, so it enables these new variables to be used instead of a job name and instance

![Screenshot from 2021-07-28 09-51-53](https://user-images.githubusercontent.com/449228/127334224-2851042f-c2cd-453f-9d43-2caf8121e3c4.png)

### Checklist

- [ ] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.

### Other Notes

I wasn't sure if this needed unit tests based on the tests I already saw for plugins. Happy to add them if you think it's necessary!