### PR TITLE
Add metrix_prefix option to Cowboy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ PromEx provides the following utilities to you in order to achieve your observab
 | `PromEx.Plugins.Oban`            | Stable      | Collect queue processing metrics emitted by Oban       |
 | `PromEx.Plugins.PhoenixLiveView` | Stable      | Collect metrics emitted by Phoenix LiveView            |
 | `PromEx.Plugins.Absinthe`        | Beta        | Collect GraphQL metrics emitted by Absinthe            |
+| `PromEx.Plugins.PlugCowboy`      | Beta        | Collect HTTP request metrics emitted by Plug.Cowboy    |
 | `PromEx.Plugins.Broadway`        | Coming soon | Collect message processing metrics emitted by Broadway |
 | `PromEx.Plugins.Finch`           | Coming soon | Collect HTTP request metrics emitted by Finch          |
 | `PromEx.Plugins.Redix`           | Coming soon | Collect Redis request metrics emitted by Redix         |

--- a/lib/prom_ex/plugins/plug_cowboy.ex
+++ b/lib/prom_ex/plugins/plug_cowboy.ex
@@ -11,6 +11,10 @@ if Code.ensure_loaded?(Plug.Cowboy) do
     - `routers`: **Required** This is a list with the full module names of your Routers (e.g MyAppWeb.Router).
       Phoenix and Plug routers are supported. When the Phoenix dependency is present in your project, a list of Phoenix Routers is expected. Otherwise a list of Plug.Router modules must be provided
     - `event_prefix`: **Optional**, allows you to set the event prefix for the Telemetry events.
+    - `metric_prefix`: This option is OPTIONAL and is used to override the default metric prefix of
+    `[otp_app, :prom_ex, :plug_cowboy]`. If this changes you will also want to set `plug_cowboy_metric_prefix`
+    in your `dashboard_assigns` to the snakecase version of your prefix, the default
+    `plug_cowboy_metric_prefix` is `{otp_app}_prom_ex_plug_cowboy`.
 
 
 
@@ -74,7 +78,7 @@ if Code.ensure_loaded?(Plug.Cowboy) do
     @impl true
     def event_metrics(opts) do
       otp_app = Keyword.fetch!(opts, :otp_app)
-      metric_prefix = PromEx.metric_prefix(otp_app, :plug_cowboy)
+      metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :plug_cowboy))
 
       [
         http_events(metric_prefix, opts)
@@ -159,7 +163,7 @@ if Code.ensure_loaded?(Plug.Cowboy) do
           counter(
             metric_prefix ++ [:http, :requests, :total],
             event_name: cowboy_stop_event,
-            description: "The number of requests have been serviced.",
+            description: "The number of requests that have been serviced.",
             drop: drop_ignored(ignore_routes),
             tag_values: &get_tags(&1, routers),
             tags: http_metrics_tags

--- a/priv/plug_cowboy.json.eex
+++ b/priv/plug_cowboy.json.eex
@@ -116,7 +116,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "(\n  (\n    sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[24h])) + \n    (sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"1024\", status=~\"2..\"}[24h])) - sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[24h]))) / 2\n  ) \n  / \n  sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", status=~\"2..\"}[24h]))\n) * 100",
+          "expr": "(\n  (\n    sum(increase(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[24h])) + \n    (sum(increase(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"1024\", status=~\"2..\"}[24h])) - sum(increase(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[24h]))) / 2\n  ) \n  / \n  sum(increase(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", status=~\"2..\"}[24h]))\n) * 100",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -180,7 +180,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[24h])) / sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{job=\"$job\", instance=\"$instance\"}[24h])) OR on() vector(0)",
+          "expr": "sum(increase(<%= @plug_cowboy_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[24h])) / sum(increase(<%= @plug_cowboy_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[24h])) OR on() vector(0)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -236,7 +236,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[24h]))",
+          "expr": "sum(increase(<%= @plug_cowboy_metric_prefix %>_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[24h]))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -292,7 +292,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{job=\"$job\", instance=\"$instance\"}[24h]))",
+          "expr": "sum(increase(<%= @plug_cowboy_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[24h]))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -357,7 +357,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "(\n  (\n    sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[1h])) + \n    (sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"1024\", status=~\"2..\"}[1h])) - sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[1h]))) / 2\n  ) \n  / \n  sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", status=~\"2..\"}[1h]))\n) * 100",
+          "expr": "(\n  (\n    sum(increase(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[1h])) + \n    (sum(increase(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"1024\", status=~\"2..\"}[1h])) - sum(increase(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\", le=\"256\", status=~\"2..\"}[1h]))) / 2\n  ) \n  / \n  sum(increase(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", status=~\"2..\"}[1h]))\n) * 100",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -422,7 +422,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[1h])) / sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{job=\"$job\", instance=\"$instance\"}[1h])) OR on() vector(0)",
+          "expr": "sum(increase(<%= @plug_cowboy_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\", status=~\"4..|5..\"}[1h])) / sum(increase(<%= @plug_cowboy_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[1h])) OR on() vector(0)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -478,7 +478,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[1h]))",
+          "expr": "sum(increase(<%= @plug_cowboy_metric_prefix %>_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[1h]))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -534,7 +534,7 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "sum(increase(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{job=\"$job\", instance=\"$instance\"}[1h]))",
+          "expr": "sum(increase(<%= @plug_cowboy_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[1h]))",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -598,7 +598,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -670,7 +670,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_response_size_bytes_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
+          "expr": "sum(irate(<%= @plug_cowboy_metric_prefix %>_http_response_size_bytes_bucket{job=\"$job\", instance=\"$instance\"}[$interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "interval": "",
@@ -754,7 +754,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status) / sum(irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status)",
+          "expr": "sum(irate(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status) / sum(irate(<%= @plug_cowboy_metric_prefix %>_http_request_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status)",
           "interval": "",
           "legendFormat": "{{ method }} {{ path }} :: {{ status }}",
           "refId": "A"
@@ -851,7 +851,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status) / sum(irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_response_size_bytes_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status)",
+          "expr": "sum(irate(<%= @plug_cowboy_metric_prefix %>_http_response_size_bytes_sum{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status) / sum(irate(<%= @plug_cowboy_metric_prefix %>_http_response_size_bytes_count{job=\"$job\", instance=\"$instance\"}[$interval])) by(path, status)",
           "interval": "",
           "legendFormat": "{{ method }} {{ path }} :: {{ status }}",
           "refId": "A"
@@ -948,7 +948,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{job=\"$job\", instance=\"$instance\"}[$interval])",
+          "expr": "irate(<%= @plug_cowboy_metric_prefix %>_http_requests_total{job=\"$job\", instance=\"$instance\"}[$interval])",
           "interval": "",
           "legendFormat": "{{ method }} {{ path }} :: {{ status }}",
           "refId": "A"
@@ -1043,19 +1043,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{status=~\"2..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
+          "expr": "sum(irate(<%= @plug_cowboy_metric_prefix %>_http_requests_total{status=~\"2..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
           "interval": "",
           "legendFormat": "2xx",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{status=~\"4..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
+          "expr": "sum(irate(<%= @plug_cowboy_metric_prefix %>_http_requests_total{status=~\"4..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
           "interval": "",
           "legendFormat": "4xx",
           "refId": "B"
         },
         {
-          "expr": "sum(irate(<%= @otp_app %>_prom_ex_plug_cowboy_http_requests_total{status=~\"5..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
+          "expr": "sum(irate(<%= @plug_cowboy_metric_prefix %>_http_requests_total{status=~\"5..\", job=\"$job\", instance=\"$instance\"}[$interval]))",
           "interval": "",
           "legendFormat": "5xx",
           "refId": "C"
@@ -1117,14 +1117,14 @@
           "value": "elixir_app"
         },
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "definition": "label_values(<%= @plug_cowboy_metric_prefix %>_prom_ex_prom_ex_status_info, job)",
         "hide": 0,
         "includeAll": false,
         "label": "Prometheus Job",
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, job)",
+        "query": "label_values(<%= @plug_cowboy_metric_prefix %>_prom_ex_prom_ex_status_info, job)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1143,14 +1143,14 @@
           "value": "host.docker.internal:4001"
         },
         "datasource": "<%= @datasource_id %>",
-        "definition": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "definition": "label_values(<%= @plug_cowboy_metric_prefix %>_prom_ex_prom_ex_status_info, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "Application Instance",
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(<%= @otp_app %>_prom_ex_prom_ex_status_info, instance)",
+        "query": "label_values(<%= @plug_cowboy_metric_prefix %>_prom_ex_prom_ex_status_info, instance)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/test/support/metrics/plug_cowboy.txt
+++ b/test/support/metrics/plug_cowboy.txt
@@ -1,6 +1,6 @@
 # HELP web_app_prom_ex_plug_cowboy_http_request_body_duration_milliseconds The time it takes for the application to receive the HTTP request body.
 # HELP web_app_prom_ex_plug_cowboy_http_request_duration_milliseconds The time it takes for the application to process HTTP requests.
-# HELP web_app_prom_ex_plug_cowboy_http_requests_total The number of requests have been serviced.
+# HELP web_app_prom_ex_plug_cowboy_http_requests_total The number of requests that have been serviced.
 # HELP web_app_prom_ex_plug_cowboy_http_response_duration_milliseconds The time it takes for the application to send the HTTP response.
 # HELP web_app_prom_ex_plug_cowboy_http_response_size_bytes The size of the HTTP response payload.
 # HELP web_app_prom_ex_prom_ex_status_info Information regarding the PromEx library. Primarily used as a source of truth for Prometheus default labels.


### PR DESCRIPTION
- An option `metric_prefix` was added in akoutmos/prom_ex#83, but
wasn't applied to the PlugCowboy plugin
- Add readme line item about cowboy plugin
- Fix wording in one cowboy metric help text
- Adjust cowboy default dashboard for new metrix_prefix

### Change description

Add `metric_prefix` to cowboy plugin

### Example usage

### Additional details and screenshots

Tested with plugins configured like...
```elixir
      {Plugins.Application, metric_prefix: [:prom_ex, :application]},
      {Plugins.Beam, metric_prefix: [:prom_ex, :beam]},
      {Plugins.Ecto, metric_prefix: [:prom_ex, :ecto]},
      {Plugins.Phoenix,
       metric_prefix: [:prom_ex, :phoenix], router: Redacted.Router, event_prefix: [:spidey, :endpoint]},
      {Plugins.PlugCowboy,
       metric_prefix: [:prom_ex, :cowboy], routers: [Redacted.Router], ignore_routes: ["/metrics"]},
      {Plugins.PromEx, metric_prefix: [:prom_ex, :prom_ex]}
```

### Checklist

- [x] I have _edited_ unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
