### PR TITLE
Adds :total_time metric to ecto plugin

### DIFF
--- a/example_applications/web_app/lib/web_app_web/telemetry.ex
+++ b/example_applications/web_app/lib/web_app_web/telemetry.ex
@@ -36,6 +36,7 @@ defmodule WebAppWeb.Telemetry do
       summary("web_app.repo.query.query_time", unit: {:native, :millisecond}),
       summary("web_app.repo.query.queue_time", unit: {:native, :millisecond}),
       summary("web_app.repo.query.idle_time", unit: {:native, :millisecond}),
+      summary("web_app.repo.query.total_time", unit: {:native, :millisecond}),
 
       # VM Metrics
       summary("vm.memory.total", unit: {:byte, :kilobyte}),

--- a/lib/prom_ex/plugins/ecto.ex
+++ b/lib/prom_ex/plugins/ecto.ex
@@ -180,6 +180,20 @@ if Code.ensure_loaded?(Ecto) do
             unit: {:native, :millisecond}
           ),
 
+          # Capture the total time (the sum of all other measurements)
+          distribution(
+            metric_prefix ++ [:repo, :query, :total, :time, :milliseconds],
+            event_name: @query_event,
+            measurement: :total_time,
+            description: "The sum of the other time measurements.",
+            tags: [:repo, :source, :command],
+            tag_values: &ecto_query_tag_values/1,
+            reporter_options: [
+              buckets: [1, 10, 50, 100, 500, 1_000, 5_000, 10_000]
+            ],
+            unit: {:native, :millisecond}
+          ),
+
           # Capture the number of results returned
           distribution(
             metric_prefix ++ [:repo, :query, :results, :returned],

--- a/test/support/metrics/ecto.txt
+++ b/test/support/metrics/ecto.txt
@@ -1,146 +1,203 @@
-# HELP web_app_prom_ex_prom_ex_status_info Information regarding the PromEx library. Primarily used as a source of truth for Prometheus default labels.
-# TYPE web_app_prom_ex_prom_ex_status_info gauge
-web_app_prom_ex_prom_ex_status_info 1
-# HELP web_app_prom_ex_ecto_repo_query_results_returned The number of result rows returned from a query.
-# TYPE web_app_prom_ex_ecto_repo_query_results_returned histogram
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="10"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="50"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="100"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="250"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="500"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1000"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="5000"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_sum{command="select",repo="WebApp.Repo",source="source_unavailable"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_count{command="select",repo="WebApp.Repo",source="source_unavailable"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1"} 39
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="10"} 43
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="50"} 43
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="100"} 43
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="250"} 43
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="500"} 43
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1000"} 43
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="5000"} 43
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 43
-web_app_prom_ex_ecto_repo_query_results_returned_sum{command="update",repo="WebApp.Repo",source="oban_jobs"} 54
-web_app_prom_ex_ecto_repo_query_results_returned_count{command="update",repo="WebApp.Repo",source="oban_jobs"} 43
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1"} 0
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="10"} 0
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="50"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="100"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="250"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="500"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1000"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="5000"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 4
-web_app_prom_ex_ecto_repo_query_results_returned_sum{command="select",repo="WebApp.Repo",source="oban_jobs"} 103
-web_app_prom_ex_ecto_repo_query_results_returned_count{command="select",repo="WebApp.Repo",source="oban_jobs"} 4
-# HELP web_app_prom_ex_ecto_repo_query_execution_time_milliseconds The time spent executing the query.
-# TYPE web_app_prom_ex_ecto_repo_query_execution_time_milliseconds histogram
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1"} 1
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="10"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="50"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="100"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="500"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1000"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="5000"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="10000"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="select",repo="WebApp.Repo",source="oban_jobs"} 5.401299999999999
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="select",repo="WebApp.Repo",source="oban_jobs"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1"} 0
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="10"} 39
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="50"} 43
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="100"} 43
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="500"} 43
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1000"} 43
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="5000"} 43
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="10000"} 43
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 43
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="update",repo="WebApp.Repo",source="oban_jobs"} 214.21989999999997
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="update",repo="WebApp.Repo",source="oban_jobs"} 43
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="1"} 13
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="10"} 24
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="50"} 24
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="100"} 24
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="500"} 24
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="1000"} 24
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="5000"} 24
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="10000"} 24
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 24
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="begin",repo="WebApp.Repo",source="source_unavailable"} 41.873
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="begin",repo="WebApp.Repo",source="source_unavailable"} 24
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="1"} 0
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="10"} 22
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="50"} 23
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="100"} 23
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="500"} 23
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="1000"} 23
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="5000"} 23
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="10000"} 23
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 23
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="commit",repo="WebApp.Repo",source="source_unavailable"} 58.188500000000005
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="commit",repo="WebApp.Repo",source="source_unavailable"} 23
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="10"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="50"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="100"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="500"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1000"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="5000"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="10000"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 4
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="select",repo="WebApp.Repo",source="source_unavailable"} 2.3524
-web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="select",repo="WebApp.Repo",source="source_unavailable"} 4
-# HELP web_app_prom_ex_ecto_repo_query_decode_time_milliseconds The time spent decoding the data received from the database.
-# TYPE web_app_prom_ex_ecto_repo_query_decode_time_milliseconds histogram
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="1"} 51
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="10"} 51
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="50"} 51
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="100"} 51
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="500"} 51
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="1000"} 51
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="5000"} 51
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="10000"} 51
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="+Inf"} 51
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_sum{repo="WebApp.Repo"} 0.8852
-web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_count{repo="WebApp.Repo"} 51
-# HELP web_app_prom_ex_ecto_repo_query_queue_time_milliseconds The time spent waiting to check out a database connection.
-# TYPE web_app_prom_ex_ecto_repo_query_queue_time_milliseconds histogram
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="1"} 34
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="10"} 43
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="50"} 43
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="100"} 43
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="500"} 43
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="1000"} 43
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="5000"} 43
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="10000"} 43
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="+Inf"} 43
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_sum{repo="WebApp.Repo"} 39.889399999999995
-web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_count{repo="WebApp.Repo"} 43
-# HELP web_app_prom_ex_ecto_repo_query_idle_time_milliseconds The time the connection spent waiting before being checked out for the query.
-# TYPE web_app_prom_ex_ecto_repo_query_idle_time_milliseconds histogram
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="1"} 0
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="10"} 0
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="50"} 2
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="100"} 7
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="500"} 16
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="1000"} 25
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="5000"} 43
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="10000"} 43
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="+Inf"} 43
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_sum{repo="WebApp.Repo"} 29656.035299999996
-web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_count{repo="WebApp.Repo"} 43
-# HELP web_app_prom_ex_ecto_repo_init_timeout_duration The configured timeout value for the repo.
-# TYPE web_app_prom_ex_ecto_repo_init_timeout_duration gauge
-web_app_prom_ex_ecto_repo_init_timeout_duration{repo="WebApp.Repo2"} 15000
-web_app_prom_ex_ecto_repo_init_timeout_duration{repo="WebApp.Repo"} 15000
 # HELP web_app_prom_ex_ecto_repo_init_pool_size The configured pool size value for the repo.
+# HELP web_app_prom_ex_ecto_repo_init_status_info Information regarding the initialized repo.
+# HELP web_app_prom_ex_ecto_repo_init_timeout_duration The configured timeout value for the repo.
+# HELP web_app_prom_ex_ecto_repo_query_decode_time_milliseconds The time spent decoding the data received from the database.
+# HELP web_app_prom_ex_ecto_repo_query_execution_time_milliseconds The time spent executing the query.
+# HELP web_app_prom_ex_ecto_repo_query_idle_time_milliseconds The time the connection spent waiting before being checked out for the query.
+# HELP web_app_prom_ex_ecto_repo_query_queue_time_milliseconds The time spent waiting to check out a database connection.
+# HELP web_app_prom_ex_ecto_repo_query_results_returned The number of result rows returned from a query.
+# HELP web_app_prom_ex_ecto_repo_query_total_time_milliseconds The sum of the other time measurements.
+# HELP web_app_prom_ex_prom_ex_status_info Information regarding the PromEx library. Primarily used as a source of truth for Prometheus default labels.
 # TYPE web_app_prom_ex_ecto_repo_init_pool_size gauge
+# TYPE web_app_prom_ex_ecto_repo_init_status_info gauge
+# TYPE web_app_prom_ex_ecto_repo_init_timeout_duration gauge
+# TYPE web_app_prom_ex_ecto_repo_query_decode_time_milliseconds histogram
+# TYPE web_app_prom_ex_ecto_repo_query_execution_time_milliseconds histogram
+# TYPE web_app_prom_ex_ecto_repo_query_idle_time_milliseconds histogram
+# TYPE web_app_prom_ex_ecto_repo_query_queue_time_milliseconds histogram
+# TYPE web_app_prom_ex_ecto_repo_query_results_returned histogram
+# TYPE web_app_prom_ex_ecto_repo_query_total_time_milliseconds histogram
+# TYPE web_app_prom_ex_prom_ex_status_info gauge
 web_app_prom_ex_ecto_repo_init_pool_size{repo="WebApp.Repo"} 10
 web_app_prom_ex_ecto_repo_init_pool_size{repo="WebApp.Repo2"} 10
-# HELP web_app_prom_ex_ecto_repo_init_status_info Information regarding the initialized repo.
-# TYPE web_app_prom_ex_ecto_repo_init_status_info gauge
-web_app_prom_ex_ecto_repo_init_status_info{database_host="postgres",database_name="web_app_dev",repo="WebApp.Repo2"} 1
 web_app_prom_ex_ecto_repo_init_status_info{database_host="postgres",database_name="web_app_dev",repo="WebApp.Repo"} 1
+web_app_prom_ex_ecto_repo_init_status_info{database_host="postgres",database_name="web_app_dev",repo="WebApp.Repo2"} 1
+web_app_prom_ex_ecto_repo_init_timeout_duration{repo="WebApp.Repo"} 15000
+web_app_prom_ex_ecto_repo_init_timeout_duration{repo="WebApp.Repo2"} 15000
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="+Inf"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="1"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="10"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="100"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="1000"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="10000"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="50"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="500"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_bucket{repo="WebApp.Repo",le="5000"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_count{repo="WebApp.Repo"} 51
+web_app_prom_ex_ecto_repo_query_decode_time_milliseconds_sum{repo="WebApp.Repo"} 0.8852
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 24
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="1"} 13
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="10"} 24
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="100"} 24
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="1000"} 24
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="10000"} 24
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="50"} 24
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="500"} 24
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="5000"} 24
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 23
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="1"} 0
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="10"} 22
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="100"} 23
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="1000"} 23
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="10000"} 23
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="50"} 23
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="500"} 23
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="5000"} 23
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1"} 1
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="10"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="100"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1000"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="10000"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="50"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="500"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="5000"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="10"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="100"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1000"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="10000"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="50"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="500"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="5000"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 43
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1"} 0
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="10"} 39
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="100"} 43
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1000"} 43
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="10000"} 43
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="50"} 43
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="500"} 43
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="5000"} 43
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="begin",repo="WebApp.Repo",source="source_unavailable"} 24
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="commit",repo="WebApp.Repo",source="source_unavailable"} 23
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="select",repo="WebApp.Repo",source="oban_jobs"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="select",repo="WebApp.Repo",source="source_unavailable"} 4
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_count{command="update",repo="WebApp.Repo",source="oban_jobs"} 43
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="begin",repo="WebApp.Repo",source="source_unavailable"} 41.873
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="commit",repo="WebApp.Repo",source="source_unavailable"} 58.188500000000005
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="select",repo="WebApp.Repo",source="oban_jobs"} 5.401299999999999
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="select",repo="WebApp.Repo",source="source_unavailable"} 2.3524
+web_app_prom_ex_ecto_repo_query_execution_time_milliseconds_sum{command="update",repo="WebApp.Repo",source="oban_jobs"} 214.21989999999997
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="+Inf"} 43
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="1"} 0
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="10"} 0
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="100"} 7
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="1000"} 25
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="10000"} 43
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="50"} 2
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="500"} 16
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_bucket{repo="WebApp.Repo",le="5000"} 43
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_count{repo="WebApp.Repo"} 43
+web_app_prom_ex_ecto_repo_query_idle_time_milliseconds_sum{repo="WebApp.Repo"} 29656.035299999996
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="+Inf"} 43
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="1"} 34
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="10"} 43
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="100"} 43
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="1000"} 43
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="10000"} 43
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="50"} 43
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="500"} 43
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_bucket{repo="WebApp.Repo",le="5000"} 43
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_count{repo="WebApp.Repo"} 43
+web_app_prom_ex_ecto_repo_query_queue_time_milliseconds_sum{repo="WebApp.Repo"} 39.889399999999995
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1"} 0
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="10"} 0
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="100"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1000"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="250"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="50"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="500"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="5000"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="10"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="100"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1000"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="250"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="50"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="500"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="5000"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 43
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1"} 39
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="10"} 43
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="100"} 43
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1000"} 43
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="250"} 43
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="50"} 43
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="500"} 43
+web_app_prom_ex_ecto_repo_query_results_returned_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="5000"} 43
+web_app_prom_ex_ecto_repo_query_results_returned_count{command="select",repo="WebApp.Repo",source="oban_jobs"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_count{command="select",repo="WebApp.Repo",source="source_unavailable"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_count{command="update",repo="WebApp.Repo",source="oban_jobs"} 43
+web_app_prom_ex_ecto_repo_query_results_returned_sum{command="select",repo="WebApp.Repo",source="oban_jobs"} 103
+web_app_prom_ex_ecto_repo_query_results_returned_sum{command="select",repo="WebApp.Repo",source="source_unavailable"} 4
+web_app_prom_ex_ecto_repo_query_results_returned_sum{command="update",repo="WebApp.Repo",source="oban_jobs"} 54
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 24
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="1"} 11
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="10"} 24
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="100"} 24
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="1000"} 24
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="10000"} 24
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="50"} 24
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="500"} 24
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="begin",repo="WebApp.Repo",source="source_unavailable",le="5000"} 24
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 23
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="1"} 0
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="10"} 22
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="100"} 23
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="1000"} 23
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="10000"} 23
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="50"} 23
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="500"} 23
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="commit",repo="WebApp.Repo",source="source_unavailable",le="5000"} 23
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1"} 1
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="10"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="100"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="1000"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="10000"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="50"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="500"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="oban_jobs",le="5000"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="+Inf"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1"} 3
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="10"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="100"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="1000"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="10000"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="50"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="500"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="select",repo="WebApp.Repo",source="source_unavailable",le="5000"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="+Inf"} 43
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1"} 0
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="10"} 37
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="100"} 43
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="1000"} 43
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="10000"} 43
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="50"} 43
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="500"} 43
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_bucket{command="update",repo="WebApp.Repo",source="oban_jobs",le="5000"} 43
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_count{command="begin",repo="WebApp.Repo",source="source_unavailable"} 24
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_count{command="commit",repo="WebApp.Repo",source="source_unavailable"} 23
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_count{command="select",repo="WebApp.Repo",source="oban_jobs"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_count{command="select",repo="WebApp.Repo",source="source_unavailable"} 4
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_count{command="update",repo="WebApp.Repo",source="oban_jobs"} 43
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_sum{command="begin",repo="WebApp.Repo",source="source_unavailable"} 45.1773
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_sum{command="commit",repo="WebApp.Repo",source="source_unavailable"} 58.188500000000005
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_sum{command="select",repo="WebApp.Repo",source="oban_jobs"} 5.469799999999999
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_sum{command="select",repo="WebApp.Repo",source="source_unavailable"} 2.4145000000000003
+web_app_prom_ex_ecto_repo_query_total_time_milliseconds_sum{command="update",repo="WebApp.Repo",source="oban_jobs"} 251.5596
+web_app_prom_ex_prom_ex_status_info 1


### PR DESCRIPTION
### Change description

All other measurments included in ecto for query timing were already included in the ecto plugin of prom_ex.
:total_time was missing, which put the burden on the end user doing a long series of sum()'s in prometheus.

### What problem does this solve?

Missing ecto :total_time metric.

### Additional details and screenshots

- [ecto description of total_time](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/repo.ex#L148)
- [ecto_sql setting of total_time](https://github.com/elixir-ecto/ecto_sql/blob/master/lib/ecto/adapters/sql.ex#L951)

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests 
