### PR TITLE
Telemetry was added to plug_cowboy in 2.4.x

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule PromEx.MixProject do
       {:telemetry_poller, "~> 0.5.1"},
       {:telemetry_metrics, "~> 0.6.0"},
       {:telemetry_metrics_prometheus_core, "~> 1.0.1"},
-      {:plug_cowboy, "~> 2.1"},
+      {:plug_cowboy, ">= 2.4.0"},
 
       # Optional dependencies depending on what telemetry events the user is interested in capturing
       {:phoenix, ">= 1.5.0", optional: true},


### PR DESCRIPTION
### Change description

According to hexdocs, it appears like telemetry was not added to plug_cowboy until 2.4.0.  We should update this dependency as it is causing confusion when folks aren't seeing telemetry events.
