### PR TITLE
Fix PlugRouter to handle request not resolved by Plug.Router

### DIFF
--- a/lib/prom_ex/plugins/plug_router.ex
+++ b/lib/prom_ex/plugins/plug_router.ex
@@ -208,28 +208,45 @@ if Code.ensure_loaded?(Plug.Router) do
       end
     end
 
-    defp path(conn) do
-      {path, _} = conn.private.plug_route
-      path
+    defp route(%Plug.Conn{private: %{plug_route: {route, _}}}) do
+      route
+    end
+
+    defp route(_conn) do
+      "Unknown"
+    end
+
+    defp route_or_path(conn) do
+      with {route, _} <- Map.get(conn.private, :plug_route) do
+        route
+      else
+        nil ->
+          conn.request_path
+      end
     end
 
     defp get_tags(%{conn: conn = %Conn{}}) do
       %{
         status: conn.status || 500,
         method: conn.method,
-        path: path(conn)
+        path: route(conn)
       }
     end
 
     defp drop_ignored(ignored_routes, routers) do
       fn
         %{conn: conn = %Conn{}, router: router} ->
-          path = path(conn)
+          value = route_or_path(conn)
 
           disallowed_router? = !Enum.member?(routers, router)
-          ignored_route? = MapSet.member?(ignored_routes, path)
-
+          ignored_route? = MapSet.member?(ignored_routes, value)
           disallowed_router? || ignored_route?
+
+        %{conn: conn = %Conn{}} ->
+          value = route_or_path(conn)
+
+          ignored_route? = MapSet.member?(ignored_routes, value)
+          ignored_route?
 
         _meta ->
           false

--- a/lib/prom_ex/plugins/plug_router.ex
+++ b/lib/prom_ex/plugins/plug_router.ex
@@ -217,9 +217,10 @@ if Code.ensure_loaded?(Plug.Router) do
     end
 
     defp route_or_path(conn) do
-      with {route, _} <- Map.get(conn.private, :plug_route) do
-        route
-      else
+      case Map.get(conn.private, :plug_route) do
+        {route, _} ->
+          route
+
         nil ->
           conn.request_path
       end


### PR DESCRIPTION
### Change description

handles request without `conn.private.plug_route` info

- sets path tag as `Unknown` for those cases
- allows ignoring a request by comparing the `:ignore_routes` option values against the request `conn.request_path` when no `conn.private.plug_route` is present
### What problem does this solve?

Issue number: #95

### Example usage

Plugin usage continues to be the same

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
