### PR TITLE
Updated telemetry_poller dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule PromEx.MixProject do
       {:jason, "~> 1.2"},
       {:finch, "~> 0.8.0"},
       {:telemetry, ">= 0.4.0"},
-      {:telemetry_poller, "~> 0.5.1"},
+      {:telemetry_poller, "~> 1.0.0"},
       {:telemetry_metrics, "~> 0.6.0"},
       {:telemetry_metrics_prometheus_core, "~> 1.0.1"},
       {:plug_cowboy, ">= 2.4.0"},


### PR DESCRIPTION
Fixes dependency issue with Phoenix 1.6.0

```
Failed to use "telemetry_poller" (version 1.0.0) because
  prom_ex (version 1.4.1) requires ~> 0.5.1
  mix.lock specifies 1.0.0

** (Mix) Hex dependency resolution failed, change the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}
```