### PR TITLE
Bump finch version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule PromEx.MixProject do
     [
       # Required dependencies
       {:jason, "~> 1.2"},
-      {:finch, "~> 0.8.0"},
+      {:finch, "~> 0.9.0"},
       {:telemetry, "~> 1.0.0"},
       {:telemetry_poller, "~> 1.0.0"},
       {:telemetry_metrics, "~> 0.6.1"},


### PR DESCRIPTION
### Change description

Bump `finch` dependency to `0.9.0`

### What problem does this solve?

Currently, we have some dependencies that do not play well together:

With `master` `prom_ex` (`phoenix` at `1.6.0`) and `finch` at `0.8.0`:
```
Failed to use "telemetry" (version 1.0.0) because
  deps/promex/mix.exs requires ~> 1.0.0
  ecto_sql (version 3.7.1) requires ~> 0.4.0 or ~> 1.0
  finch (version 0.8.0) requires ~> 0.4
```

With `master` `prom_ex` and `finch` at `0.9.0`, which is compatible with `telemetry` `1.0.0`:
```
Failed to use "finch" (version 0.9.0) because
  deps/promex/mix.exs requires ~> 0.8.0
  mix.lock specifies 0.9.0
```

This PR updates `finch` so everything plays nicely together.

### Checklist

- [N/A] I have added unit tests to cover my changes.
- [N/A] I have added documentation to cover my changes.
- [X] My changes have passed unit tests and have been tested E2E in an example project.
