### PR TITLE
Remove warning logs about missing GIT_* env vars

### DIFF
--- a/lib/prom_ex/lifecycle_annotator.ex
+++ b/lib/prom_ex/lifecycle_annotator.ex
@@ -56,7 +56,6 @@ defmodule PromEx.LifecycleAnnotator do
           git_sha
 
         :error ->
-          Logger.warn("GIT_SHA environment variable has not been defined")
           "Not available"
       end
 
@@ -66,7 +65,6 @@ defmodule PromEx.LifecycleAnnotator do
           git_sha
 
         :error ->
-          Logger.warn("GIT_AUTHOR environment variable has not been defined")
           "Not available"
       end
 


### PR DESCRIPTION
Hello,

### Change description

I propose to remove these logs entries as not having those variable set won't cause any problem. Or maybe better, we could not add these git related informations in the annotation if they are not present. What do you think?


### What problem does this solve?

It avoid noise in logs.

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
