### PR TITLE
Make source links in docs link to the correct branch

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -76,6 +76,7 @@ defmodule PromEx.MixProject do
   defp docs do
     [
       main: "readme",
+      source_ref: "master",
       logo: "guides/images/logo.svg",
       extras: [
         "README.md",


### PR DESCRIPTION
### Change description

Make source links in docs link to the correct branch

### What problem does this solve?

Getting to a 404 when clicking such a link

Issue number: (if applicable)

### Example usage

### Additional details and screenshots

https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html

> `:source_ref` - The branch/commit/tag used for source link inference; default: "main".

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
