### PR TITLE
Add documentation for needed transform to Broadway

### DIFF
--- a/lib/prom_ex/plugins/broadway.ex
+++ b/lib/prom_ex/plugins/broadway.ex
@@ -30,6 +30,32 @@ if Code.ensure_loaded?(Broadway) do
       end
     end
     ```
+
+    To correctly capture per-message metrics and error rate, add the following transform to your pipeline:
+    ```
+    defmodule WebApp.MyPipeline do
+      use Broadway
+
+      alias Broadway.Message
+
+      def start_link(_opts) do
+        Broadway.start_link(__MODULE__,
+          name: __MODULE__,
+          producer: [
+            ...
+            transformer: {__MODULE__, :transform, []}
+          ]
+        )
+      end
+
+      def transform(event, _opts) do
+        %Message{
+          data: event,
+          acknowledger: {__MODULE__, :ack_id, :ack_data}
+        }
+      end
+    end
+    ```
     """
 
     use PromEx.Plugin


### PR DESCRIPTION
Closes #114

### Change description
Added a section to the Broadway plugin documentation that points out the use of a transform to add correct 'acknowledger'.

### What problem does this solve?
Incorrectly tagged values that cannot be found by the Grafana Broadway dashboard, when the 'acknowledger' is set to the default, namely the name of the Broadway producer module.

Issue number: #114

### Example usage
Examine docs to verify the change.

### Additional details and screenshots
Built docs
![image](https://user-images.githubusercontent.com/11848465/153223966-cea18820-9329-4730-bde5-ca74ac5a17ec.png)

### Checklist

- [ ] I have added unit tests to cover my changes.
- [X] I have added documentation to cover my changes.
- [X] My changes have passed unit tests and have been tested E2E in an example project.
