### PR TITLE
Fix Grafana broadway.json to name message percentages as success rates

### DIFF
--- a/priv/broadway.json.eex
+++ b/priv/broadway.json.eex
@@ -549,7 +549,7 @@
     },
     {
       "datasource": "<%= @datasource_id %>",
-      "description": "A percentage of Broadway message that resulted in an error over the past 24 hours.",
+      "description": "A percentage of Broadway messages that did not result in errors over the past 24 hours.",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -615,7 +615,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Message Error Percentage (Last 24h)",
+      "title": "Message Success Percentage (Last 24h)",
       "type": "stat"
     },
     {
@@ -736,7 +736,7 @@
     },
     {
       "datasource": "<%= @datasource_id %>",
-      "description": "A percentage of Broadway message that resulted in an error over the past hour.",
+      "description": "A percentage of Broadway messages that did not result in errors over the past hour.",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -802,7 +802,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Message Error Percentage (Last 1h)",
+      "title": "Message Success Percentage (Last 1h)",
       "type": "stat"
     },
     {


### PR DESCRIPTION
### Change description
Change text and description of the 'Message Error Percentage' panels in Grafana broadway.json dashboard to name them as 'Message Success Percentage' instead.

### What problem does this solve?
Currently the calculation and coloring (green-to-red) defines 100% as no errors and all successes. The text and description of the panels are reversed to the actual.

Here a screenshot from a run with no errors:
![image](https://user-images.githubusercontent.com/11848465/153226262-ccf64e4c-e89f-496f-b4dc-07594f7deec3.png)

Issue number: N/A

### Example usage
No usage

### Additional details and screenshots
None

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
