### PR TITLE
Grafana client generalization

### DIFF
--- a/lib/prom_ex.ex
+++ b/lib/prom_ex.ex
@@ -152,6 +152,7 @@ defmodule PromEx do
     manual_metrics_name = Module.concat([calling_module, ManualMetricsManager])
     metrics_collector_name = Module.concat([calling_module, Metrics])
     dashboard_uploader_name = Module.concat([calling_module, DashboardUploader])
+    grafana_client_name = Module.concat([calling_module, GrafanaClient])
     metrics_server_name = Module.concat([calling_module, MetricsServer])
     lifecycle_annotator_name = Module.concat([calling_module, LifecycleAnnotator])
 
@@ -205,6 +206,11 @@ defmodule PromEx do
               unquote(manual_metrics_name)
             )
             |> PromEx.poller_child_specs(poll_metrics, __MODULE__)
+            |> PromEx.grafana_client_child_spec(
+              grafana_config,
+              __MODULE__,
+              unquote(grafana_client_name)
+            )
             |> PromEx.dashboard_uploader_child_spec(
               grafana_config,
               __MODULE__,
@@ -303,6 +309,9 @@ defmodule PromEx do
       def __metrics_collector_name__, do: unquote(metrics_collector_name)
 
       @doc false
+      def __grafana_client_name__, do: unquote(grafana_client_name)
+
+      @doc false
       def __dashboard_uploader_name__, do: unquote(dashboard_uploader_name)
 
       @doc false
@@ -384,6 +393,17 @@ defmodule PromEx do
     telemetry_poller_children = generate_telemetry_poller_child_spec(prom_ex_module, metrics)
 
     telemetry_poller_children ++ acc
+  end
+
+  @doc false
+  def grafana_client_child_spec(acc, :disabled, _, _) do
+    acc
+  end
+
+  def grafana_client_child_spec(acc, _, _, process_name) do
+    spec = {PromEx.GrafanaClient, name: process_name}
+
+    [spec | acc]
   end
 
   @doc false

--- a/lib/prom_ex/dashboard_uploader.ex
+++ b/lib/prom_ex/dashboard_uploader.ex
@@ -19,7 +19,7 @@ defmodule PromEx.DashboardUploader do
 
   require Logger
 
-  alias PromEx.{DashboardRenderer, GrafanaClient, GrafanaClient.Connection}
+  alias PromEx.{DashboardRenderer, GrafanaClient}
 
   @doc """
   Used to start the DashboardUploader process
@@ -45,11 +45,7 @@ defmodule PromEx.DashboardUploader do
     } = state
 
     %PromEx.Config{grafana_config: grafana_config} = prom_ex_module.init_opts()
-
-    # Start Finch process and build Grafana connection
-    finch_name = Module.concat([prom_ex_module, __MODULE__, Finch])
-    Finch.start_link(name: finch_name)
-    grafana_conn = Connection.build(finch_name, grafana_config)
+    grafana_conn = GrafanaClient.build_conn(prom_ex_module)
 
     upload_opts =
       case grafana_config.folder_name do
@@ -75,11 +71,6 @@ defmodule PromEx.DashboardUploader do
           )
       end
     end)
-
-    # No longer need this short-lived Finch process
-    finch_name
-    |> Process.whereis()
-    |> Process.exit(:normal)
 
     # Kill the uploader process as there is no more work to do
     {:stop, :normal, :ok}

--- a/lib/prom_ex/grafana_client.ex
+++ b/lib/prom_ex/grafana_client.ex
@@ -27,6 +27,7 @@ defmodule PromEx.GrafanaClient do
            | {:error, reason :: Mint.TransportError.t()}
 
   @doc false
+  @spec child_spec(term) :: Supervisor.child_spec()
   def child_spec(init_arg) do
     Finch.child_spec(init_arg)
   end

--- a/lib/prom_ex/grafana_client.ex
+++ b/lib/prom_ex/grafana_client.ex
@@ -187,6 +187,8 @@ defmodule PromEx.GrafanaClient do
       |> Map.new(fn
         {:dashboard_id, v} -> {:dashboardId, v}
         {:panel_id, v} -> {:panelId, v}
+        {:time, %DateTime{} = dt} -> {:time, DateTime.to_unix(dt, :millisecond)}
+        {:time_end, %DateTime{} = dt} -> {:timeEnd, DateTime.to_unix(dt, :millisecond)}
         {:time_end, v} -> {:timeEnd, v}
         {k, v} -> {k, v}
       end)

--- a/test/prom_ex/dashboard_uploader_test.exs
+++ b/test/prom_ex/dashboard_uploader_test.exs
@@ -95,6 +95,12 @@ defmodule PromEx.DashboardUploaderTest do
       Plug.Conn.resp(conn, 401, response_payload)
     end)
 
+    {:ok, _} =
+      start_supervised(
+        {PromEx.GrafanaClient, [name: DefaultPromExSetUp.__grafana_client_name__()]},
+        restart: :temporary
+      )
+
     assert capture_log(fn ->
              {:ok, pid} =
                start_supervised(
@@ -161,6 +167,12 @@ defmodule PromEx.DashboardUploaderTest do
       Plug.Conn.resp(conn, 200, response_payload)
     end)
 
+    {:ok, _} =
+      start_supervised(
+        {PromEx.GrafanaClient, [name: CustomDashboardApplyFunction.__grafana_client_name__()]},
+        restart: :temporary
+      )
+
     assert capture_log(fn ->
              {:ok, pid} =
                start_supervised(
@@ -220,6 +232,12 @@ defmodule PromEx.DashboardUploaderTest do
     Bypass.expect_once(bypass, "POST", "/api/dashboards/db", fn conn ->
       Plug.Conn.resp(conn, 200, response_payload)
     end)
+
+    {:ok, _} =
+      start_supervised(
+        {PromEx.GrafanaClient, [name: DefaultPromExSetUp.__grafana_client_name__()]},
+        restart: :temporary
+      )
 
     assert capture_log(fn ->
              {:ok, pid} =
@@ -294,6 +312,12 @@ defmodule PromEx.DashboardUploaderTest do
 
       Plug.Conn.resp(conn, 200, response_payload)
     end)
+
+    {:ok, _} =
+      start_supervised(
+        {PromEx.GrafanaClient, [name: DefaultPromExSetUp.__grafana_client_name__()]},
+        restart: :temporary
+      )
 
     assert capture_log(fn ->
              {:ok, pid} =
@@ -397,6 +421,12 @@ defmodule PromEx.DashboardUploaderTest do
 
       Plug.Conn.resp(conn, 200, response_payload)
     end)
+
+    {:ok, _} =
+      start_supervised(
+        {PromEx.GrafanaClient, [name: DefaultPromExSetUp.__grafana_client_name__()]},
+        restart: :temporary
+      )
 
     logs =
       capture_log(fn ->

--- a/test/prom_ex/grafana_client_test.exs
+++ b/test/prom_ex/grafana_client_test.exs
@@ -46,7 +46,7 @@ defmodule PromEx.GrafanaClientTest do
       {:ok, body, conn} = Plug.Conn.read_body(conn, [])
 
       details = Jason.decode!(body)
-      assert details["time"] == "2022-01-01T00:00:00Z"
+      assert details["time"] == 1_640_995_200_000
       assert details["tags"] == ["some", "tags"]
       assert details["text"] == "message"
       assert %{} == Map.drop(details, ["time", "tags", "text"])
@@ -89,8 +89,8 @@ defmodule PromEx.GrafanaClientTest do
       details = Jason.decode!(body)
       assert details["dashboardId"] == 1
       assert details["panelId"] == 2
-      assert details["time"] == "2022-01-01T00:00:00Z"
-      assert details["timeEnd"] == "2022-01-02T00:00:00Z"
+      assert details["time"] == 1_640_995_200_000
+      assert details["timeEnd"] == 1_641_081_600_000
       assert details["tags"] == ["some", "tags"]
       assert details["text"] == "message"
 

--- a/test/prom_ex/grafana_client_test.exs
+++ b/test/prom_ex/grafana_client_test.exs
@@ -1,0 +1,118 @@
+defmodule PromEx.GrafanaClientTest do
+  use ExUnit.Case, async: false
+
+  alias PromEx.GrafanaClient
+
+  defmodule DefaultPromExSetUp do
+    use PromEx, otp_app: :prom_ex
+
+    @impl true
+    def plugins do
+      []
+    end
+
+    @impl true
+    def dashboards do
+      []
+    end
+  end
+
+  @moduletag :capture_log
+
+  setup do
+    bypass = Bypass.open()
+    {:ok, bypass: bypass}
+  end
+
+  test "allows for custom annotations being created", %{bypass: bypass} do
+    response_payload = """
+    {
+      "message":"Annotation added",
+      "id": 1
+    }
+    """
+
+    Application.put_env(:prom_ex, DefaultPromExSetUp,
+      grafana: [
+        host: endpoint_url(bypass.port),
+        auth_token: "random_token",
+        folder_name: "Web App Dashboards",
+        upload_dashboards_on_start: false,
+        annotate_app_lifecycle: true
+      ]
+    )
+
+    Bypass.expect(bypass, "POST", "/api/annotations", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn, [])
+
+      details = Jason.decode!(body)
+      assert details["time"] == "2022-01-01T00:00:00Z"
+      assert details["tags"] == ["some", "tags"]
+      assert details["text"] == "message"
+      assert %{} == Map.drop(details, ["time", "tags", "text"])
+
+      Plug.Conn.resp(conn, 200, response_payload)
+    end)
+
+    {:ok, _} =
+      start_supervised(
+        {GrafanaClient, [name: DefaultPromExSetUp.__grafana_client_name__()]},
+        restart: :temporary
+      )
+
+    conn = GrafanaClient.build_conn(DefaultPromExSetUp)
+
+    assert {:ok, _} = GrafanaClient.create_annotation(conn, ["some", "tags"], "message", time: ~U[2022-01-01 00:00:00Z])
+  end
+
+  test "custom annotations handle key casing", %{bypass: bypass} do
+    response_payload = """
+    {
+      "message":"Annotation added",
+      "id": 1
+    }
+    """
+
+    Application.put_env(:prom_ex, DefaultPromExSetUp,
+      grafana: [
+        host: endpoint_url(bypass.port),
+        auth_token: "random_token",
+        folder_name: "Web App Dashboards",
+        upload_dashboards_on_start: false,
+        annotate_app_lifecycle: true
+      ]
+    )
+
+    Bypass.expect(bypass, "POST", "/api/annotations", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn, [])
+
+      details = Jason.decode!(body)
+      assert details["dashboardId"] == 1
+      assert details["panelId"] == 2
+      assert details["time"] == "2022-01-01T00:00:00Z"
+      assert details["timeEnd"] == "2022-01-02T00:00:00Z"
+      assert details["tags"] == ["some", "tags"]
+      assert details["text"] == "message"
+
+      Plug.Conn.resp(conn, 200, response_payload)
+    end)
+
+    {:ok, _} =
+      start_supervised(
+        {GrafanaClient, [name: DefaultPromExSetUp.__grafana_client_name__()]},
+        restart: :temporary
+      )
+
+    conn = GrafanaClient.build_conn(DefaultPromExSetUp)
+
+    assert {:ok, _} =
+             GrafanaClient.create_annotation(conn, ["some", "tags"], "message",
+               time: ~U[2022-01-01 00:00:00Z],
+               time_end: ~U[2022-01-02 00:00:00Z],
+               dashboard_id: 1,
+               panel_id: 2
+             )
+  end
+
+  defp endpoint_url(port), do: "http://localhost:#{port}/"
+end

--- a/test/prom_ex/lifecycle_annotator_test.exs
+++ b/test/prom_ex/lifecycle_annotator_test.exs
@@ -53,6 +53,12 @@ defmodule PromEx.LifecycleAnnotatorTest do
       Plug.Conn.resp(conn, 200, response_payload)
     end)
 
+    {:ok, _} =
+      start_supervised(
+        {PromEx.GrafanaClient, [name: DefaultPromExSetUp.__grafana_client_name__()]},
+        restart: :temporary
+      )
+
     {:ok, pid} =
       start_supervised(
         {


### PR DESCRIPTION
### Change description

Makes `PromEx.GrafanaClient` more generally useful beyond supporting the dashboard uploader and the lifecycle annotations.

### What problem does this solve?

[Slack Thread](https://elixir-lang.slack.com/archives/C01NZ0FBFSR/p1644012540991449)

### Example usage

```elixir
conn = GrafanaClient.build_conn(MyApp.PromEx)

{:ok, _} = 
  GrafanaClient.create_annotation(conn, ["some", "tags"], "something happened",
    time: ~U[2022-01-01 00:00:00Z],
    time_end: ~U[2022-01-02 00:00:00Z],
    dashboard_id: 1,
    panel_id: 2
  )
```

### Additional details and screenshots

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
