### PR TITLE
Make the folder UID part of the string that gets MD5'd to generate dashboard UID

### DIFF
--- a/lib/prom_ex.ex
+++ b/lib/prom_ex.ex
@@ -301,7 +301,8 @@ defmodule PromEx do
         module_name = Atom.to_string(__MODULE__)
         dashboard_otp_app_name = Atom.to_string(dashboard_otp_app)
 
-        string_uid = "#{otp_app_name}:#{module_name}:#{dashboard_otp_app_name}:#{dashboard_path}:#{dashboard_title}"
+        string_uid =
+          "#{otp_app_name}:#{module_name}:#{dashboard_otp_app_name}:#{__MODULE__.__grafana_folder_uid__()}:#{dashboard_path}:#{dashboard_title}"
 
         # Grafana limits us to 40 character UIDs...so taking the MD5 of
         # a complete unique identifier to use as the UID


### PR DESCRIPTION
### Change description

Make the folder UID part of the string that gets MD5'd to generate dashboard UID

### What problem does this solve?

Issue number: https://github.com/akoutmos/prom_ex/issues/57

### Example usage

Just use as normal, and if you have a codebase with 2 deployments environments uploading dashboards to GrafanaCloud, they won't overwrite each other.

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
