### PR TITLE
Relax telemetry versioning requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,10 +47,10 @@ defmodule PromEx.MixProject do
       # Required dependencies
       {:jason, "~> 1.2"},
       {:finch, "~> 0.10.2"},
-      {:telemetry, "~> 1.0.0"},
-      {:telemetry_poller, "~> 1.0.0"},
+      {:telemetry, "~> 1.0"},
+      {:telemetry_poller, "~> 1.0"},
       {:telemetry_metrics, "~> 0.6.1"},
-      {:telemetry_metrics_prometheus_core, "~> 1.0.2"},
+      {:telemetry_metrics_prometheus_core, "~> 1.0"},
       {:plug_cowboy, "~> 2.5.1"},
 
       # Optional dependencies depending on what telemetry events the user is interested in capturing


### PR DESCRIPTION
### Change description

### What problem does this solve?

Allows upgrading of Telemetry once https://github.com/beam-telemetry/telemetry_metrics_prometheus_core/pull/45 is released.

### Example usage

### Additional details and screenshots

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
