### PR TITLE
Fix: Use topology name for message and exception tags

### DIFF
--- a/test/prom_ex/plugins/broadway_test.exs
+++ b/test/prom_ex/plugins/broadway_test.exs
@@ -1,8 +1,16 @@
 defmodule PromEx.Plugins.BroadwayTest do
   use ExUnit.Case, async: true
 
+  alias PromEx.MetricTypes.Event
   alias PromEx.Plugins.Broadway
   alias PromEx.Test.Support.{Events, Metrics}
+  alias Telemetry.Metrics.Distribution
+
+  @default_metadata %{
+    processor_key: :default,
+    topology_name: Elixir.SomeModule,
+    message: %Elixir.Broadway.Message{acknowledger: {Elixir.SomeAcker}, data: %{}}
+  }
 
   defmodule WebApp.PromEx do
     use PromEx, otp_app: :web_app
@@ -23,5 +31,29 @@ defmodule PromEx.Plugins.BroadwayTest do
       |> Metrics.sort()
 
     assert metrics == Metrics.read_expected(:broadway)
+  end
+
+  describe "event_metrics/1" do
+    test "returns topology_name for message tags" do
+      metric = assert_event_metric(:broadway_message_event_metrics, [:broadway, :processor, :message, :stop])
+      assert %{name: "SomeModule", processor_key: :default} = metric.tag_values.(@default_metadata)
+    end
+
+    test "returns topology_name for message exception tags" do
+      metric = assert_event_metric(:broadway_message_event_metrics, [:broadway, :processor, :message, :exception])
+      exception_metadata = Map.merge(@default_metadata, %{kind: Error, reason: "notsure", stacktrace: []})
+      assert %{name: "SomeModule", processor_key: :default} = metric.tag_values.(exception_metadata)
+    end
+
+    defp assert_event_metric(metric_group, event) do
+      assert event_metrics = Broadway.event_metrics(otp_app: :web_app)
+
+      assert %Event{metrics: message_metrics} =
+               Enum.find(event_metrics, fn metrics -> metrics.group_name == metric_group end)
+
+      assert %Distribution{} = metric = Enum.find(message_metrics, fn dist -> dist.event_name == event end)
+
+      metric
+    end
   end
 end


### PR DESCRIPTION
### What problem does this solve?
While using `BroadwayRabbitMQ.Producer`for  Broadway, we were not able to override the message acknowledger according to the docs as there is a unique `:delivery_tag` required to ack messages to RMQ.   When we tried, this was empty and our messages were not being acked.

Second, the metrics were not showing up for the RabbitMQ backed pipeline, but they were for a pipeline using a normal GenStage producer and after some digging around, I noticed that the `:name` tag/label on the `/metrics` were different:

### GenStage Producer Metric
```bash
broadway_process_message_duration_milliseconds_count{batcher="local",name="Prom.Pipelines.LocalPipeline"}
```

### RabbitMQ Producer Metric
```bash
broadway_process_message_duration_milliseconds_count{batcher="rabbit",name="BroadwayRabbitMQ.Producer"}
```

### Changes
After switching the tag_values function to use `:topology_name`, the metrics for both Pipelines started to show up accurately in Grafana.

Curious if there was a reason to use the message acknowledger for the name tags?  BroadwayRabbitMQ emits different events for acking/ rejecting.  

I'd be happy to add those in a separate PR.  Wanted to keep this one short. 

Issue number: N/A

### Example usage
- I created an app with two pipelines, one with a GenStage Producer and one with a RabbitMQ Producer both with a 10% error rates.
- After making these changes, the metrics started to show up accurately in the Grafana dashboard, including exception rates and batch failures.

### Additional details and screenshots

### GenStage Pipeline
<img width="1983" alt="genstage-pipeline" src="https://user-images.githubusercontent.com/11931030/162602650-a0bc8764-1610-4f38-afab-0c004ecc884e.png">

### RabbitMQ Pipeline

<img width="1979" alt="rabbit-pipeline" src="https://user-images.githubusercontent.com/11931030/162602658-c58f7673-47ac-409d-8b44-777493103bd6.png">

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
