### PR TITLE
Add  `duration_unit` option to Ecto plugin

### DIFF
--- a/lib/prom_ex/plugins/application.ex
+++ b/lib/prom_ex/plugins/application.ex
@@ -24,6 +24,9 @@ defmodule PromEx.Plugins.Application do
     in your `dashboard_assigns` to the snakecase version of your prefix, the default
     `application_metric_prefix` is `{otp_app}_prom_ex_application`.
 
+  - `duration_unit`: This is an OPTIONAL option and is a `Telemetry.Metrics.time_unit()`. It can be one of:
+    `:second | :millisecond | :microsecond | :nanosecond`. It is `:millisecond` by default.
+
   This plugin exposes the following metric groups:
   - `:application_versions_manual_metrics`
 
@@ -119,6 +122,8 @@ defmodule PromEx.Plugins.Application do
     otp_app = Keyword.fetch!(opts, :otp_app)
     poll_rate = Keyword.get(opts, :poll_rate, 5_000)
     metric_prefix = Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :application))
+    duration_unit = Keyword.get(opts, :duration_unit, :millisecond)
+    duration_unit_plural = PromEx.Utils.make_plural_atom(duration_unit)
 
     Polling.build(
       :application_time_polling_metrics,
@@ -126,11 +131,12 @@ defmodule PromEx.Plugins.Application do
       {__MODULE__, :execute_time_metrics, []},
       [
         last_value(
-          metric_prefix ++ [:uptime, :milliseconds, :count],
+          metric_prefix ++ [:uptime, duration_unit_plural, :count],
           event_name: [:prom_ex, :plugin, :application, :uptime, :count],
-          description: "The total number of wall clock milliseconds that have passed since the application started.",
+          description:
+            "The total number of wall clock #{duration_unit_plural} that have passed since the application started.",
           measurement: :count,
-          unit: :millisecond
+          unit: duration_unit
         )
       ]
     )

--- a/lib/prom_ex/utils.ex
+++ b/lib/prom_ex/utils.ex
@@ -7,6 +7,8 @@ defmodule PromEx.Utils do
   @typedoc "The kinds of exceptions that can occur"
   @type exception_kind :: :error | :exit | :throw
 
+  @type duration_unit_plural :: :seconds | :milliseconds | :microseconds | :nanoseconds
+
   @doc """
   Take a module name and normalize it for use as a metric
   label.
@@ -53,5 +55,13 @@ defmodule PromEx.Utils do
 
   def normalize_exception(_kind, _reason, _stacktrace) do
     "UnknownException"
+  end
+
+  @doc """
+  Converts a `time_unit` to its plural form.
+  """
+  @spec make_plural_atom(System.time_unit()) :: atom()
+  def make_plural_atom(word) do
+    String.to_existing_atom("#{Atom.to_string(word)}s")
   end
 end


### PR DESCRIPTION
### Change description
This change adds a new optional option to the `Ecto` plugin configuration - `duration_unit`.
It allows the user to override the time unit of the `Ecto` metrics, allowing to directly pass it through to `:telemetry`.

### What problem does this solve?

Issue number: #139 

### Example usage

```elixir
{Plugins.Ecto, [repos: [Shared.Repo], duration_unit: :second]}
```

### Additional details and screenshots

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
