### PR TITLE
add new metric for Oban Job, total time inserted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New Oban plugin metric, total inserted time, the diff of inserted_at and attempted_at
+
 ## [1.7.1] - 2021-03-02
 
 ### Fixed

--- a/test/support/metrics/oban.txt
+++ b/test/support/metrics/oban.txt
@@ -132,6 +132,35 @@ web_app_prom_ex_oban_job_queue_time_milliseconds_bucket{name="Oban",queue="media
 web_app_prom_ex_oban_job_queue_time_milliseconds_bucket{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker",le="+Inf"} 3
 web_app_prom_ex_oban_job_queue_time_milliseconds_sum{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker"} 137.731
 web_app_prom_ex_oban_job_queue_time_milliseconds_count{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker"} 3
+# HELP web_app_prom_ex_oban_job_inserted_time_milliseconds The amount of time from Oban job insertion to job attempt.
+# TYPE web_app_prom_ex_oban_job_inserted_time_milliseconds histogram
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker",le="+Inf"} 8
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker",le="10"} 8
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker",le="100"} 8
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker",le="1000"} 8
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker",le="20000"} 8
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker",le="500"} 8
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker",le="5000"} 8
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="events",state="success",worker="WebApp.Jobs.EventWorker",le="+Inf"} 1
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="events",state="success",worker="WebApp.Jobs.EventWorker",le="10"} 1
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="events",state="success",worker="WebApp.Jobs.EventWorker",le="100"} 1
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="events",state="success",worker="WebApp.Jobs.EventWorker",le="1000"} 1
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="events",state="success",worker="WebApp.Jobs.EventWorker",le="20000"} 1
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="events",state="success",worker="WebApp.Jobs.EventWorker",le="500"} 1
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="events",state="success",worker="WebApp.Jobs.EventWorker",le="5000"} 1
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker",le="+Inf"} 3
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker",le="10"} 3
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker",le="100"} 3
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker",le="1000"} 3
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker",le="20000"} 3
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker",le="500"} 3
+web_app_prom_ex_oban_job_inserted_time_milliseconds_bucket{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker",le="5000"} 3
+web_app_prom_ex_oban_job_inserted_time_milliseconds_count{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker"} 8
+web_app_prom_ex_oban_job_inserted_time_milliseconds_count{name="Oban",queue="events",state="success",worker="WebApp.Jobs.EventWorker"} 1
+web_app_prom_ex_oban_job_inserted_time_milliseconds_count{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker"} 3
+web_app_prom_ex_oban_job_inserted_time_milliseconds_sum{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker"} 0.38451099999999994
+web_app_prom_ex_oban_job_inserted_time_milliseconds_sum{name="Oban",queue="events",state="success",worker="WebApp.Jobs.EventWorker"} 4.2999999999999995e-5
+web_app_prom_ex_oban_job_inserted_time_milliseconds_sum{name="Oban",queue="media",state="success",worker="WebApp.Jobs.MediaWorker"} 1.37e-4
 # HELP web_app_prom_ex_oban_job_processing_duration_milliseconds The amount of time it takes to processes an Oban job.
 # TYPE web_app_prom_ex_oban_job_processing_duration_milliseconds histogram
 web_app_prom_ex_oban_job_processing_duration_milliseconds_bucket{name="Oban",queue="default",state="success",worker="WebApp.Jobs.DefaultWorker",le="10"} 0


### PR DESCRIPTION
### Change description

New metric for the Oban plugin, the total time the job spent in the DB before being attempted.

### What problem does this solve?

Issue number: n/a

We wanted to track how long a job took from insertion to attempt.  Normally queued time would tell you this but we snooze jobs and the queue time gets reset when you reinsert the job.

### Example usage

### Additional details and screenshots

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
