### PR TITLE
fix-telemetry-example

### DIFF
--- a/guides/howtos/Telemetry.md
+++ b/guides/howtos/Telemetry.md
@@ -72,8 +72,8 @@ doing the following:
 
 ```elixir
 :telemetry.attach(
+  "my-handler-1",
   [:my_cool_app, :accounts, :new_user, :success],
-  query_event,
   fn _event_name, _event_measurement, event_metadata, _config ->
     Logger.debug("User has registered: #{inspect(event_metadata)}")
   end,
@@ -81,8 +81,8 @@ doing the following:
 )
 
 :telemetry.attach(
+  "my-handler-2",
   [:my_cool_app, :accounts, :new_user, :error],
-  query_event,
   fn _event_name, _event_measurement, event_metadata, _config ->
     Logger.warn("User failed to register: #{inspect(event_metadata)}")
   end,


### PR DESCRIPTION
### Change description

Fixes the telemetry example, which had the incorrect order of arguments.  According to the [telemetry docs](https://hexdocs.pm/telemetry/telemetry.html#attach/4) the event name is supposed to be the second argument, not the first.  It was also unclear what `query_event` was referring to as it appears no where else in the documentation.

### What problem does this solve?

N/A

Issue number: N/A

### Example usage

N/A

### Additional details and screenshots

N/A

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
