### PR TITLE
Run multiple Grafana Agent processes

### DIFF
--- a/guides/howtos/Running Multiple Agents.md
+++ b/guides/howtos/Running Multiple Agents.md
@@ -1,0 +1,55 @@
+# Running Multiple Agents
+
+Suppose you want to send your metrics to two separate Prometheus databases, and define two separate sets of dashboards - one for the ops team, and one for the business team.
+You can do this by creating two PromEx configurations.
+
+To generate distinct PromEx modules:
+
+```sh
+mix prom_ex.gen.config -d ops -m PromExOps
+mix prom_ex.gen.config -d biz -m PromExBiz
+```
+
+Each PromEx config will run its own Grafana Agent. You need to configure `working_directory`, `agent_port` and `grpc_port` to make sure they don't collide:
+
+```elixir
+config :my_app, MyApp.PromExOps,
+  grafana_agent: [
+    working_directory: System.fetch_env!("RELEASE_TMP") <> "/grafana-ops",
+    config_opts: [
+      ...
+      agent_port: 4040,
+      grpc_port: 9040
+    ]
+  ]
+
+config :my_app, MyApp.PromExBiz,
+  grafana_agent: [
+    working_directory: System.fetch_env!("RELEASE_TMP") <> "/grafana-biz",
+    config_opts: [
+      ...
+      agent_port: 4041,
+      grpc_port: 9041
+    ]
+  ]
+```
+
+Add each module to your application's supervisor per the directions in the generated PromEx file.
+
+## Endpoints
+
+You can configure each agent to scrape the same set of metrics:
+
+```elixir
+# endpoint.ex
+plug PromEx.Plug, prom_ex_module: MyApp.PromExOps
+
+# in mix config, set `metrics_server_path: "/metrics"`
+```
+
+or define separate endpoints:
+
+```elixir
+plug PromEx.Plug, prom_ex_module: MyApp.PromExOps, path: "/metrics/ops"
+plug PromEx.Plug, prom_ex_module: MyApp.PromExBiz, path: "/metrics/biz"
+```

--- a/lib/prom_ex/config.ex
+++ b/lib/prom_ex/config.ex
@@ -176,6 +176,8 @@ defmodule PromEx.Config do
 
       * `:agent_port` - What port should GrafanaAgent run on.
 
+      * `:grpc_port` - What port should GrafanaAgent gRPC server run on.
+
       * `:scrape_interval` - How often should GrafanaAgent scrape the application. The default is `15s`.
 
       * `:bearer_token` - The bearer token that GrafanaAgent should attach to the request to your app.
@@ -325,6 +327,7 @@ defmodule PromEx.Config do
       bearer_token: Keyword.get(opts, :bearer_token, "blank"),
       log_level: Keyword.get(opts, :log_level, "error"),
       agent_port: Keyword.get(opts, :agent_port, "4040"),
+      grpc_port: Keyword.get(opts, :grpc_port, "9095"),
       job: Keyword.get(opts, :job, nil),
       instance: Keyword.get(opts, :instance, nil),
       prometheus_url: get_grafana_agent_config(opts, :prometheus_url),

--- a/lib/prom_ex/grafana_agent.ex
+++ b/lib/prom_ex/grafana_agent.ex
@@ -95,7 +95,7 @@ defmodule PromEx.GrafanaAgent do
     end
   end
 
-  defp do_download_grafana_agent(%{grafana_agent_config: config} = state) do
+  defp do_download_grafana_agent(%{grafana_agent_config: config, prom_ex_module: prom_ex_module} = state) do
     # Get the root path where all GrafanaAgent related items will reside
     base_directory = get_base_directory(state)
 
@@ -108,7 +108,7 @@ defmodule PromEx.GrafanaAgent do
 
     # Download the configured GrafanaAgent binary
     config.version
-    |> Downloader.download_grafana_agent(download_dir, bin_dir)
+    |> Downloader.download_grafana_agent(download_dir, bin_dir, prom_ex_module)
     |> case do
       {:ok, binary_path} ->
         binary_path

--- a/mix.exs
+++ b/mix.exs
@@ -82,6 +82,7 @@ defmodule PromEx.MixProject do
         "README.md",
         "guides/howtos/Writing PromEx Plugins.md",
         "guides/howtos/Telemetry.md",
+        "guides/howtos/Running Multiple Agents.md",
         "guides/gallery/All.md"
       ],
       groups_for_extras: [

--- a/priv/grafana_agent/default_config.yml.eex
+++ b/priv/grafana_agent/default_config.yml.eex
@@ -1,5 +1,6 @@
 server:
   http_listen_port: <%= @agent_port %>
+  grpc_listen_port: <%= @grpc_port %>
   log_level: <%= @log_level %>
 
 prometheus:

--- a/test/mix/tasks/prom_ex.gen.config_test.exs
+++ b/test/mix/tasks/prom_ex.gen.config_test.exs
@@ -48,6 +48,20 @@ defmodule Mix.Tasks.PromEx.Gen.ConfigTest do
     assert contents =~ ~r/use PromEx, otp_app: :sample/
   end
 
+  test "module can be provided as an arg", ctx do
+    capture_io(fn ->
+      File.cd!(ctx.tmp_dir, fn -> run(~w(-d an_id -o sample -m AnotherPromEx)) end)
+    end)
+
+    contents =
+      ctx.sample_app_dir
+      |> Path.join("another_prom_ex.ex")
+      |> File.read!()
+
+    # Module name
+    assert contents =~ ~r/defmodule Sample.AnotherPromEx/
+  end
+
   test "prompts user for confirmation if config is already generated", ctx do
     # File did not exist previously
     assert capture_io(fn ->

--- a/test/prom_ex/grafana_agent/config_renderer_test.exs
+++ b/test/prom_ex/grafana_agent/config_renderer_test.exs
@@ -8,6 +8,7 @@ defmodule PromEx.GrafanaAgent.ConfigRendererTest do
     test "should generate a configuration yaml file with the correct substitutions", %{tmp_dir: tmp_dir} do
       template_args = %{
         agent_port: "12345",
+        grpc_port: "54321",
         log_level: "error",
         wal_dir: "/tmp/test/wal",
         scrape_interval: "5s",

--- a/test/prom_ex/grafana_agent/expected_output_config.yml
+++ b/test/prom_ex/grafana_agent/expected_output_config.yml
@@ -1,5 +1,6 @@
 server:
   http_listen_port: 12345
+  grpc_listen_port: 54321
   log_level: error
 
 prometheus:


### PR DESCRIPTION
### Change description

- Permit parallel grafana agent downloader processes
- Configure grafana agent gRPC port
- Add `-m` option to generator to specify PromEx module name

This allows us to configure multiple PromEx processes within our own application.

### What problem does this solve?

We want to record metrics and publish dashboards to multiple sources (e.g. one for ops team, and one for biz team).

### Example usage

Configure multiple PromEx processes and add them each to the supervisor:

```elixir
  config :my_app, Core.PromExBiz,
    ...
    grafana: [
      host: "http://localhost:3000",
      ...
      folder_name: "myapp-biz"
    ],
    grafana_agent: [
      working_directory: Path.expand(".grafana_biz"),
      config_opts: [
        metrics_server_path: "/metrics/biz",
        ...
        instance: "dev-biz",
        prometheus_url: "http://prometheus-biz:9090/api/v1/write",
        ...
        agent_port: 4040,
        grpc_port: 9040
      ]
    ]

  config :my_app, Core.PromExOps,
    ...
    grafana: [
      host: "http://localhost:3000",
      ...
      folder_name: "myapp-ops"
    ],
    grafana_agent: [
      working_directory: Path.expand(".grafana_ops"),
      config_opts: [
        metrics_server_path: "/metrics/ops",
        ...
        instance: "dev-ops",
        prometheus_url: "http://prometheus-ops:9090/api/v1/write",
        ...
        agent_port: 4141,
        grpc_port: 9041
      ]
    ]
```

### Additional details and screenshots

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
