### PR TITLE
Configurable Grafana Agent template

### DIFF
--- a/lib/prom_ex/config.ex
+++ b/lib/prom_ex/config.ex
@@ -188,6 +188,8 @@ defmodule PromEx.Config do
 
       * `:prometheus_password` - The password to the hosted Prometheus instance
 
+      * `:template_file` - The full path to the template used to render the agent config file.
+
   * `:metrics_server` - This key contains the configuration information needed to run a standalone
     HTTP server powered by Cowboy. This server provides a lightweight solution to serving up PromEx
     metrics. Its configuration options are:

--- a/lib/prom_ex/grafana_agent/config_renderer.ex
+++ b/lib/prom_ex/grafana_agent/config_renderer.ex
@@ -9,17 +9,20 @@ defmodule PromEx.GrafanaAgent.ConfigRenderer do
   """
   @spec generate_config_file(opts :: map(), config_dir :: String.t()) :: String.t()
   def generate_config_file(opts, config_dir) do
-    template_config =
-      :prom_ex
-      |> :code.priv_dir()
-      |> List.to_string()
-      |> Path.join("/grafana_agent/default_config.yml.eex")
-      |> File.read!()
-
+    template_config = File.read!(template_file(opts))
     rendered_config = EEx.eval_string(template_config, assigns: opts)
     config_file_path = Path.join(config_dir, "agent.yml")
     File.write(config_file_path, rendered_config)
 
     config_file_path
+  end
+
+  defp template_file(%{template_file: file}), do: file
+
+  defp template_file(_) do
+    :prom_ex
+    |> :code.priv_dir()
+    |> List.to_string()
+    |> Path.join("/grafana_agent/default_config.yml.eex")
   end
 end

--- a/test/prom_ex/grafana_agent/config_renderer_test.exs
+++ b/test/prom_ex/grafana_agent/config_renderer_test.exs
@@ -29,5 +29,22 @@ defmodule PromEx.GrafanaAgent.ConfigRendererTest do
       assert File.exists?(expected_file_path)
       assert File.read!(expected_file_path) == File.read!("#{__DIR__}/expected_output_config.yml")
     end
+
+    @tag :tmp_dir
+    test "should configure template", %{tmp_dir: tmp_dir} do
+      template_file = Path.join(tmp_dir, "my_template.yml.eex")
+      File.write!(template_file, "foo: <%= @foo %>")
+
+      template_args = %{
+        foo: "this is a foo",
+        template_file: template_file
+      }
+
+      ConfigRenderer.generate_config_file(template_args, tmp_dir)
+      expected_file_path = "#{tmp_dir}/agent.yml"
+
+      assert File.exists?(expected_file_path)
+      assert File.read!(expected_file_path) == "foo: this is a foo"
+    end
   end
 end


### PR DESCRIPTION
### Change description

Adds a `template_file` config to override the built-in grafana agent config template.

### What problem does this solve?

We have multiple agent configs that differ from the built-in config template. We found it was elegant to provide our own template file, and let PromEx specify any defaults and pass through our new custom config keys.

### Example usage

```elixir
config :my_app, MyApp.PromEx,
  grafana_agent: [
    ...
    config_opts: [
      ...
      template_file: Application.app_dir(:my_app, "priv/templates/grafana_agent_config.eex"),
      custom_field: "custom value" # available as <%= @custom_field %> in the template
    ]
  ]
```

### Additional details and screenshots

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
