### PR TITLE
Fix prom_ex plugin docs - change "our" to "out"

### DIFF
--- a/guides/howtos/Writing PromEx Plugins.md
+++ b/guides/howtos/Writing PromEx Plugins.md
@@ -20,7 +20,7 @@ provided to the struct `build` function.
 
 ## Adding Event Metrics
 
-To have your custom plugin expose event based metrics, implement a `event_metrics/1` function and build our a collection
+To have your custom plugin expose event based metrics, implement a `event_metrics/1` function and build out a collection
 of `Telemetry.Metrics` structs (`distribution`, `counter`, `last_value`, and `sum`). Be sure to look at plugins like
 `PromEx.Plugins.Phoenix` for more in depth examples.
 


### PR DESCRIPTION
### Change description

Fix prom_ex plugin docs - change "our" to "out"

### What problem does this solve?

Docs update

Issue number: (if applicable)

n/a

### Example usage

n/a

### Additional details and screenshots

n/a

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
