### PR TITLE
Override and pass in additional grafana agent config keys

### DIFF
--- a/lib/prom_ex/config.ex
+++ b/lib/prom_ex/config.ex
@@ -192,6 +192,8 @@ defmodule PromEx.Config do
 
       * `:template_file` - The full path to the template used to render the agent config file.
 
+      * all of these keys, and any additional ones, will be provided as EEx vars to the template file.
+
   * `:metrics_server` - This key contains the configuration information needed to run a standalone
     HTTP server powered by Cowboy. This server provides a lightweight solution to serving up PromEx
     metrics. Its configuration options are:
@@ -325,21 +327,22 @@ defmodule PromEx.Config do
 
   defp extract_opts_for_config(opts) do
     %{
-      scrape_interval: Keyword.get(opts, :scrape_interval, "15s"),
-      bearer_token: Keyword.get(opts, :bearer_token, "blank"),
-      log_level: Keyword.get(opts, :log_level, "error"),
-      agent_port: Keyword.get(opts, :agent_port, "4040"),
-      grpc_port: Keyword.get(opts, :grpc_port, "9095"),
-      job: Keyword.get(opts, :job, nil),
-      instance: Keyword.get(opts, :instance, nil),
+      scrape_interval: "15s",
+      bearer_token: "blank",
+      log_level: "error",
+      agent_port: "4040",
+      grpc_port: "9095",
+      job: nil,
+      instance: nil,
       prometheus_url: get_grafana_agent_config(opts, :prometheus_url),
       prometheus_username: get_grafana_agent_config(opts, :prometheus_username),
       prometheus_password: get_grafana_agent_config(opts, :prometheus_password),
-      metrics_server_path: Keyword.get(opts, :metrics_server_path, "/metrics"),
-      metrics_server_port: Keyword.get(opts, :metrics_server_port, 4000),
-      metrics_server_host: Keyword.get(opts, :metrics_server_host, "localhost"),
-      metrics_server_scheme: Keyword.get(opts, :metrics_server_scheme, :https)
+      metrics_server_path: "/metrics",
+      metrics_server_port: 4000,
+      metrics_server_host: "localhost",
+      metrics_server_scheme: :https
     }
+    |> Map.merge(Map.new(opts))
   end
 
   defp get_grafana_agent_config(grafana_agent_opts, config_key) do

--- a/test/prom_ex/config_test.exs
+++ b/test/prom_ex/config_test.exs
@@ -45,6 +45,77 @@ defmodule PromEx.ConfigTest do
              } = config
     end
 
+    test "should generate default grafana agent config" do
+      config =
+        Config.build(
+          grafana_agent: [
+            config_opts: [
+              prometheus_url: "https://prometheus",
+              prometheus_username: "prometheus-user",
+              prometheus_password: "prometheus-password"
+            ]
+          ]
+        )
+
+      assert %PromEx.Config{
+               grafana_agent_config: %{
+                 config_opts: %{
+                   prometheus_url: "https://prometheus",
+                   prometheus_username: "prometheus-user",
+                   prometheus_password: "prometheus-password",
+                   scrape_interval: "15s",
+                   bearer_token: "blank",
+                   log_level: "error",
+                   agent_port: "4040",
+                   grpc_port: "9095",
+                   job: nil,
+                   instance: nil,
+                   metrics_server_path: "/metrics",
+                   metrics_server_port: 4000,
+                   metrics_server_host: "localhost",
+                   metrics_server_scheme: :https
+                 }
+               }
+             } = config
+    end
+
+    test "should override existing keys, and pass additional keys to grafana agent config" do
+      config =
+        Config.build(
+          grafana_agent: [
+            config_opts: [
+              prometheus_url: "https://prometheus",
+              prometheus_username: "prometheus-user",
+              prometheus_password: "prometheus-password",
+              agent_port: "4141",
+              template_file: "path/to/template",
+              foo: "bar"
+            ]
+          ]
+        )
+
+      assert %PromEx.Config{
+               grafana_agent_config: %{
+                 config_opts: %{
+                   # required
+                   prometheus_url: "https://prometheus",
+                   prometheus_username: "prometheus-user",
+                   prometheus_password: "prometheus-password",
+
+                   # default
+                   scrape_interval: "15s",
+
+                   # override
+                   agent_port: "4141",
+
+                   # new keys
+                   template_file: "path/to/template",
+                   foo: "bar"
+                 }
+               }
+             } = config
+    end
+
     test "should raise an error if there are missing standalone metrics server fields" do
       assert_raise RuntimeError, "When configuring the PromEx metrics server, the :port key is required.", fn ->
         Config.build(metrics_server: [])


### PR DESCRIPTION
#159 was missing a commit that we had on a different branch when testing. Sorry for not being more careful there.

This permits template_file to be overridden, and for additional variables to be passed through to the template file.

### Change description

The config currently passes an explicit list of keys to grafana agent config. Any keys not in that list will not get sent.

This change allows us to send additional grafana agent config keys that will be passed through to the template file.

It's necessary to enable the functionality of #159 - without it, a `template_file` config won't get passed to the grafana agent config.

### Checklist

We have deployed this branch to production and confirmed that it fixes the problem described above.

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
