### PR TITLE
Broadway: Add example ack implementation.

### DIFF
--- a/lib/prom_ex/plugins/broadway.ex
+++ b/lib/prom_ex/plugins/broadway.ex
@@ -57,8 +57,14 @@ if Code.ensure_loaded?(Broadway) do
         }
       end
 
-      def ack(:ack_id, _successful_messages, _failed_messages) do
-        :ok
+      # Since the transformer wraps the %Broadway.Message{} in another %Broadway.Message{}, this breaks the ack so we need to manually trigger the ack.
+      def ack(:ack_id, successful_messages, failed_messages) do
+        Broadway.Acknowledger.ack_messages(
+          successful_messages
+          |> Enum.reduce([], fn %Message{data: %Message{} = message}, acc -> [message | acc] end),
+          failed_messages
+          |> Enum.reduce([], fn %Message{data: %Message{} = message}, acc -> [message | acc] end)
+        )
       end
     end
     ```


### PR DESCRIPTION
### Change description

Add an example ack implementation for the Broadway plugin.

### What problem does this solve?

Broadway only sends an ack for the parent message and not for the nested message resulting in e.g. no delete message for AWS SQS.

### Example usage

PromEx with Broadway using BroadwaySQS, BroadwayKafka, etc.

### Additional details and screenshots

TODO: Write integration test(s)?

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
