### PR TITLE
Add support Grafana Agent v0.29.0

### DIFF
--- a/lib/prom_ex/config.ex
+++ b/lib/prom_ex/config.ex
@@ -151,7 +151,7 @@ defmodule PromEx.Config do
       any malicious binaries and running them). By default, PromEx will use the result of
       `PromEx.GrafanaAgent.Downloader.default_version()` if no value is provided.
 
-      * Supported versions are `["0.23.0", "0.22.0", "0.21.2", "0.20.1"]`
+      * Supported versions are `["0.29.0", "0.23.0", "0.22.0", "0.21.2", "0.20.1"]`
 
     * `:working_directory` - In order to leverage the GrafanaAgent functionality, PromEx needs to have
       read/write access to a directory in order to download and copy the GrafanaAgent binary. This is the

--- a/lib/prom_ex/grafana_agent.ex
+++ b/lib/prom_ex/grafana_agent.ex
@@ -70,15 +70,37 @@ defmodule PromEx.GrafanaAgent do
     {:noreply, state}
   end
 
-  defp start_agent(%{port_wrapper_path: port_wrapper_path, binary_path: binary_path, config_file_path: config_file_path}) do
+  defp start_agent(
+         %{
+           port_wrapper_path: port_wrapper_path,
+           binary_path: binary_path,
+           config_file_path: config_file_path,
+           grafana_agent_config: %{
+             config_opts: %{
+               agent_port: agent_port,
+               grpc_port: grpc_port
+             }
+           }
+         } = state
+       ) do
     Logger.info("Starting GrafanaAgent")
+
+    wrapper_args = [binary_path, "-config.file", config_file_path]
+
+    wrapper_args =
+      if pre_v0_26?(state) do
+        wrapper_args
+      else
+        wrapper_args ++
+          ["-server.http.address", "127.0.0.1:#{agent_port}", "-server.grpc.address", "127.0.0.1:#{grpc_port}"]
+      end
 
     {:spawn_executable, port_wrapper_path}
     |> Port.open([
       :binary,
       :exit_status,
       :stderr_to_stdout,
-      args: [binary_path, "-config.file", config_file_path]
+      args: wrapper_args
     ])
   end
 
@@ -146,6 +168,7 @@ defmodule PromEx.GrafanaAgent do
     |> Map.get(:grafana_agent_config)
     |> Map.get(:config_opts)
     |> Map.put(:wal_dir, wal_dir)
+    |> Map.put(:render_listen_port, pre_v0_26?(state))
     |> maybe_put_job(state)
     |> maybe_put_instance()
     |> ConfigRenderer.generate_config_file(config_dir)
@@ -169,4 +192,6 @@ defmodule PromEx.GrafanaAgent do
   defp maybe_put_instance(opts) do
     opts
   end
+
+  defp pre_v0_26?(%{grafana_agent_config: %{version: version}}), do: Version.compare(version, "0.26.0") == :lt
 end

--- a/lib/prom_ex/grafana_agent/downloader.ex
+++ b/lib/prom_ex/grafana_agent/downloader.ex
@@ -7,6 +7,13 @@ defmodule PromEx.GrafanaAgent.Downloader do
     latest_version: "0.23.0",
     github_repo: "grafana/agent",
     download_versions: %{
+      "0.29.0" => [
+        {:darwin, :amd64, "2b51aab7cfa4daf9b18c857c85dddb9ee9086e7470c3585be661fd6577e15afe"},
+        {:darwin, :arm64, "4bf44f44a1e9f4e9c257bea8bcf63549bf4f8f575f8afca94ff0cac371f55ed9"},
+        {:linux, :amd64, "aa07cc24de9d607e6388ce85eec76b250f6a4f304ba86ec7e38fc351d9a2739a"},
+        {:linux, :arm64, "7d402893564e4054d7e1401d10031b9c2841832a2dab5212184f2b606cd08b0d"},
+        {:freebsd, :amd64, "28becd3451ae8d56f4976e87a622da7cd11ce8a02d9bd9f1ee6517785c7fd594"}
+      ],
       "0.23.0" => [
         {:darwin, :amd64, "643044b35ed4bdfd9866a43b70e39d64f16709f9685b89a03b299da8834661b0"},
         {:darwin, :arm64, "e94f7fd0e1ef9fb497cff4f1260cc22967d6a5b003dd2c99f494f9e457482dda"},

--- a/priv/grafana_agent/default_config.yml.eex
+++ b/priv/grafana_agent/default_config.yml.eex
@@ -1,7 +1,7 @@
 server:
+  log_level: <%= @log_level %><%= if @render_listen_port do %>
   http_listen_port: <%= @agent_port %>
-  grpc_listen_port: <%= @grpc_port %>
-  log_level: <%= @log_level %>
+  grpc_listen_port: <%= @grpc_port %><% end %>
 
 prometheus:
   wal_directory: "<%= @wal_dir %>"
@@ -17,7 +17,7 @@ prometheus:
           static_configs:
             - targets: ["<%= @metrics_server_host %>:<%= @metrics_server_port %>"]
           metric_relabel_configs:
-            - source_labels: [ instance ]
+            - source_labels: [instance]
               target_label: instance
               action: replace
               replacement: "<%= @instance %>"

--- a/test/prom_ex/grafana_agent/config_renderer_test.exs
+++ b/test/prom_ex/grafana_agent/config_renderer_test.exs
@@ -9,6 +9,7 @@ defmodule PromEx.GrafanaAgent.ConfigRendererTest do
       template_args = %{
         agent_port: "12345",
         grpc_port: "54321",
+        render_listen_port: true,
         log_level: "error",
         wal_dir: "/tmp/test/wal",
         scrape_interval: "5s",
@@ -46,6 +47,34 @@ defmodule PromEx.GrafanaAgent.ConfigRendererTest do
 
       assert File.exists?(expected_file_path)
       assert File.read!(expected_file_path) == "foo: this is a foo"
+    end
+
+    @tag :tmp_dir
+    test "should omnit agent_port and grpc_port from >= v0.26.0", %{tmp_dir: tmp_dir} do
+      template_args = %{
+        agent_port: "12345",
+        grpc_port: "54321",
+        render_listen_port: false,
+        log_level: "error",
+        wal_dir: "/tmp/test/wal",
+        scrape_interval: "5s",
+        job: "TestApp",
+        metrics_server_path: "/cool-metrics",
+        metrics_server_scheme: :https,
+        metrics_server_host: "localhost",
+        bearer_token: "super_secret",
+        metrics_server_port: "1234",
+        instance: "localhost",
+        prometheus_url: "www.my-prometheus.com",
+        prometheus_username: "prom_user",
+        prometheus_password: "prom_pass"
+      }
+
+      ConfigRenderer.generate_config_file(template_args, tmp_dir)
+      expected_file_path = "#{tmp_dir}/agent.yml"
+
+      assert File.exists?(expected_file_path)
+      assert File.read!(expected_file_path) == File.read!("#{__DIR__}/expected_output_config_post_v0_26.yml")
     end
   end
 end

--- a/test/prom_ex/grafana_agent/expected_output_config_post_v0_26.yml
+++ b/test/prom_ex/grafana_agent/expected_output_config_post_v0_26.yml
@@ -1,7 +1,5 @@
 server:
   log_level: error
-  http_listen_port: 12345
-  grpc_listen_port: 54321
 
 prometheus:
   wal_directory: "/tmp/test/wal"


### PR DESCRIPTION
### Change description

This adds support for Grafana Agent v0.29.0

Per the [Grafana Agent CHANGELOG](https://github.com/grafana/agent/blob/03b9598a4c8d70877a79d634c441d1d26609599f/CHANGELOG.md#v0260-2022-07-18), the pertinent breaking change is that `server.http_listen_port` and `server.grpc_listen_port` have been removed from the config file, and moved to command line args `-server.http.address` and `-server.grpc.address` respectively.

This change adds support for both - pre v0.26.0 is unchanged, v0.26.0 and above omits the removed keys from the default config, and passes them as flags.

It maintains v0.23.0 as the default, to not affect existing installations.

We are running this commit in prod.

### What problem does this solve?

We ran into a problem where after rebooting a machine, Grafana Agent got stuck in a crash loop trying to replay the WAL.

After some research, it seemed like various issues related to WAL replaying were resolved in newer versions.

I started using v0.29.0 and it cleared up the problem.

```
./bin/agent-freebsd-amd64 -config.file config/agent.yml
ts=2022-11-30T03:58:23.338778202Z caller=node.go:85 level=info agent=prometheus component=cluster msg="applying config"
ts=2022-11-30T03:58:23.339038349Z caller=remote.go:180 level=info agent=prometheus component=cluster msg="not watching the KV, none set"
ts=2022-11-30T03:58:23Z level=info caller=traces/traces.go:135 msg="Traces Logger Initialized" component=traces
ts=2022-11-30T03:58:23.345287748Z caller=server.go:77 level=info msg="server configuration changed, restarting server"
ts=2022-11-30T03:58:23.346898915Z caller=gokit.go:72 level=info http=[::]:4141 grpc=[::]:9041 msg="server listening on addresses"
ts=2022-11-30T03:58:23.35337069Z caller=wal.go:182 level=info agent=prometheus instance=28d1c3ee27ede0f514e148ae1918b3e8 msg="replaying WAL, this may take a while" dir=/var/run/sprlcl/grafana-biz/prom_wal/28d1c3ee27ede0f514e148ae1918b3e8/wal
panic: runtime error: index out of range [0] with length 0

goroutine 117 [running]:
github.com/prometheus/prometheus/tsdb/wal.NewSegmentBufReader(...)
	/go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20220112164627-aae84190631a/tsdb/wal/wal.go:881
github.com/prometheus/prometheus/tsdb/wal.NewSegmentsRangeReader({0xc00004b840, 0x1, 0x1})
	/go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20220112164627-aae84190631a/tsdb/wal/wal.go:863 +0x27a
github.com/prometheus/prometheus/tsdb/wal.NewSegmentsReader(...)
	/go/pkg/mod/github.com/grafana/prometheus@v1.8.2-0.20220112164627-aae84190631a/tsdb/wal/wal.go:835
github.com/grafana/agent/pkg/metrics/wal.(*Storage).replayWAL(0xc0009af0a0)
	/drone/src/pkg/metrics/wal/wal.go:189 +0x3f6
github.com/grafana/agent/pkg/metrics/wal.NewStorage({0x47dab80, 0xc0007a44b0}, {0x48162b8, 0xc000d757d0}, {0xc00014ca00, 0x45})
	/drone/src/pkg/metrics/wal/wal.go:164 +0x326
github.com/grafana/agent/pkg/metrics/instance.New.func1({0x48162b8, 0xc000d757d0})
	/drone/src/pkg/metrics/instance/instance.go:261 +0x5d
github.com/grafana/agent/pkg/metrics/instance.(*Instance).initialize(0xc000a3af20, {0x484e528, 0xc000bbe980}, {0x48162b8, 0xc000d757d0}, 0xc0009aeee0)
	/drone/src/pkg/metrics/instance/instance.go:410 +0xfe
github.com/grafana/agent/pkg/metrics/instance.(*Instance).Run(0xc000a3af20, {0x484e528, 0xc000bbe980})
	/drone/src/pkg/metrics/instance/instance.go:313 +0x38a
github.com/grafana/agent/pkg/metrics/instance.(*BasicManager).runProcess(0xc000d0cc00, {0x484e528, 0xc000bbe980}, {0xc000053c60, 0x20}, {0x4871418, 0xc000a3af20})
	/drone/src/pkg/metrics/instance/manager.go:262 +0x9e
github.com/grafana/agent/pkg/metrics/instance.(*BasicManager).spawnProcess.func1(0xc000d0cc00, {0x484e528, 0xc000bbe980}, 0xc0009aed20, {0x4871418, 0xc000a3af20}, 0xc0000c2240)
	/drone/src/pkg/metrics/instance/manager.go:232 +0x6d
created by github.com/grafana/agent/pkg/metrics/instance.(*BasicManager).spawnProcess
	/drone/src/pkg/metrics/instance/manager.go:231 +0x358
```

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
