### PR TITLE
Include event and handler name as tags with handle_in metrics

### DIFF
--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -330,12 +330,14 @@ if Code.ensure_loaded?(Phoenix) do
             reporter_options: [
               buckets: [10, 100, 500, 1_000, 5_000, 10_000]
             ],
-            tag_values: fn %{socket: %Socket{endpoint: endpoint}} ->
+            tag_values: fn %{socket: %Socket{endpoint: endpoint, handler: handler}, event: event} ->
               %{
-                endpoint: normalize_module_name(endpoint)
+                endpoint: normalize_module_name(endpoint),
+                event: event,
+                handler: handler
               }
             end,
-            tags: [:endpoint],
+            tags: [:endpoint, :handler, :event],
             unit: {:native, duration_unit}
           )
         ]

--- a/test/prom_ex/ets_cron_flusher_test.exs
+++ b/test/prom_ex/ets_cron_flusher_test.exs
@@ -43,16 +43,16 @@ defmodule PromEx.ETSCronFlusherTest do
       Events.execute_all(:phoenix)
 
       assert length(get_metrics_table(DefaultPromExSetUp)) == 5
-      assert length(get_dist_table(DefaultPromExSetUp)) == 40
+      assert length(get_dist_table(DefaultPromExSetUp)) == 42
 
       Events.execute_all(:phoenix)
 
       assert length(get_metrics_table(DefaultPromExSetUp)) == 5
-      assert length(get_dist_table(DefaultPromExSetUp)) == 80
+      assert length(get_dist_table(DefaultPromExSetUp)) == 84
 
       Process.sleep(8_000)
 
-      assert length(get_metrics_table(DefaultPromExSetUp)) == 11
+      assert length(get_metrics_table(DefaultPromExSetUp)) == 13
       assert get_dist_table(DefaultPromExSetUp) == []
 
       new_timer_ref = get_timer_ref(DefaultPromExSetUp)
@@ -73,16 +73,16 @@ defmodule PromEx.ETSCronFlusherTest do
       Events.execute_all(:phoenix)
 
       assert length(get_metrics_table(ManualPromExSetUp)) == 5
-      assert length(get_dist_table(ManualPromExSetUp)) == 40
+      assert length(get_dist_table(ManualPromExSetUp)) == 42
 
       Events.execute_all(:phoenix)
 
       assert length(get_metrics_table(ManualPromExSetUp)) == 5
-      assert length(get_dist_table(ManualPromExSetUp)) == 80
+      assert length(get_dist_table(ManualPromExSetUp)) == 84
 
       Process.sleep(3_500)
 
-      assert length(get_metrics_table(ManualPromExSetUp)) == 11
+      assert length(get_metrics_table(ManualPromExSetUp)) == 13
       assert get_dist_table(ManualPromExSetUp) == []
 
       new_timer_ref = get_timer_ref(ManualPromExSetUp)

--- a/test/prom_ex/plugins/phoenix_test.exs
+++ b/test/prom_ex/plugins/phoenix_test.exs
@@ -36,6 +36,29 @@ defmodule PromEx.Plugins.PhoenixTest do
     end
   end
 
+  defmodule WebApp.PromExSingleEndpointNormalizedChannelEvents do
+    use PromEx, otp_app: :web_app
+
+    @additional_routes [
+      special_label: "/really-cool-route",
+      another_label: ~r(\/another-cool-route)
+    ]
+
+    @impl true
+    def plugins do
+      [
+        {Phoenix,
+         router: TestApp.Router,
+         additional_routes: @additional_routes,
+         endpoint: TestApp.Endpoint,
+         normalize_event_names: fn
+           "test_event" -> "test_event"
+           _ -> "unknown"
+         end}
+      ]
+    end
+  end
+
   test "telemetry events are accumulated for single endpoint configuration" do
     start_supervised!(WebApp.PromExSingleEndpoint)
     Events.execute_all(:phoenix)
@@ -48,6 +71,15 @@ defmodule PromEx.Plugins.PhoenixTest do
     Events.execute_all(:phoenix)
 
     Metrics.assert_prom_ex_metics(WebApp.PromExMultipleEndpoint, :phoenix)
+  end
+
+  test "channel events normalize according to normalize_event_names" do
+    start_supervised!(WebApp.PromExSingleEndpointNormalizedChannelEvents)
+    Events.execute_all(:phoenix)
+
+    collected_metrics = Metrics.read_collected(WebApp.PromExSingleEndpointNormalizedChannelEvents)
+
+    assert collected_metrics |> Enum.any?(&String.contains?(&1, "unknown"))
   end
 
   describe "event_metrics/1" do

--- a/test/prom_ex/plugins/phoenix_test.exs
+++ b/test/prom_ex/plugins/phoenix_test.exs
@@ -73,7 +73,7 @@ defmodule PromEx.Plugins.PhoenixTest do
     Metrics.assert_prom_ex_metics(WebApp.PromExMultipleEndpoint, :phoenix)
   end
 
-  test "channel events normalize according to normalize_event_names" do
+  test "channel events normalize according to normalize_event_name" do
     start_supervised!(WebApp.PromExSingleEndpointNormalizedChannelEvents)
     Events.execute_all(:phoenix)
 

--- a/test/prom_ex/plugins/phoenix_test.exs
+++ b/test/prom_ex/plugins/phoenix_test.exs
@@ -51,7 +51,7 @@ defmodule PromEx.Plugins.PhoenixTest do
          router: TestApp.Router,
          additional_routes: @additional_routes,
          endpoint: TestApp.Endpoint,
-         normalize_event_names: fn
+         normalize_event_name: fn
            "test_event" -> "test_event"
            _ -> "unknown"
          end}

--- a/test/support/events/phoenix.exs
+++ b/test/support/events/phoenix.exs
@@ -2158,6 +2158,60 @@
     }
   },
   %{
+    event: [:phoenix, :channel_handled_in],
+    measurements: %{duration: 51792},
+    metadata: %{
+      event: "test_event",
+      params: %{},
+      ref: "10",
+      socket: %{
+        __struct__: Phoenix.Socket,
+        assigns: %{},
+        channel: Phoenix.LiveReloader.Channel,
+        channel_pid: nil,
+        endpoint: WebAppWeb.Endpoint,
+        handler: Phoenix.LiveReloader.Socket,
+        id: nil,
+        joined: true,
+        join_ref: "6",
+        private: %{log_handle_in: :debug, log_join: :info},
+        pubsub_server: WebApp.PubSub,
+        ref: nil,
+        serializer: Phoenix.Socket.V2.JSONSerializer,
+        topic: "phoenix:live_reload",
+        transport: :websocket,
+        transport_pid: nil
+      }
+    }
+  },
+  %{
+    event: [:phoenix, :channel_handled_in],
+    measurements: %{duration: 51792},
+    metadata: %{
+      event: "another_test_event",
+      params: %{},
+      ref: "10",
+      socket: %{
+        __struct__: Phoenix.Socket,
+        assigns: %{},
+        channel: Phoenix.LiveReloader.Channel,
+        channel_pid: nil,
+        endpoint: WebAppWeb.Endpoint,
+        handler: Phoenix.LiveReloader.Socket,
+        id: nil,
+        joined: true,
+        join_ref: "6",
+        private: %{log_handle_in: :debug, log_join: :info},
+        pubsub_server: WebApp.PubSub,
+        ref: nil,
+        serializer: Phoenix.Socket.V2.JSONSerializer,
+        topic: "phoenix:live_reload",
+        transport: :websocket,
+        transport_pid: nil
+      }
+    }
+  },
+  %{
     event: [:phoenix, :endpoint, :stop],
     measurements: %{duration: 501_930_627},
     metadata: %{

--- a/test/support/metrics.ex
+++ b/test/support/metrics.ex
@@ -12,6 +12,14 @@ defmodule PromEx.Test.Support.Metrics do
     |> sort()
   end
 
+  @spec read_collected(module()) :: [String.t()]
+  @doc false
+  def read_collected(prom_ex_module) do
+    prom_ex_module
+    |> PromEx.get_metrics()
+    |> sort()
+  end
+
   @doc false
   @spec sort(String.t()) :: [String.t()]
   def sort(metrics_string) do
@@ -23,10 +31,7 @@ defmodule PromEx.Test.Support.Metrics do
   @doc false
   @spec assert_prom_ex_metics(module(), atom()) :: :ok
   def assert_prom_ex_metics(prom_ex_module, expected_metrics_lookup) do
-    collected_metrics =
-      prom_ex_module
-      |> PromEx.get_metrics()
-      |> sort()
+    collected_metrics = read_collected(prom_ex_module)
 
     expected_metrics = read_expected(expected_metrics_lookup)
 

--- a/test/support/metrics/phoenix.txt
+++ b/test/support/metrics/phoenix.txt
@@ -4,6 +4,26 @@ web_app_prom_ex_prom_ex_status_info 1
 # HELP web_app_prom_ex_phoenix_channel_joined_total The number of channel joins that have occurred.
 # TYPE web_app_prom_ex_phoenix_channel_joined_total counter
 web_app_prom_ex_phoenix_channel_joined_total{endpoint="WebAppWeb.Endpoint",result="ok",transport="websocket"} 17
+# HELP web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds The time it takes for the application to respond to channel messages.
+# TYPE web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds histogram
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="10"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="100"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="500"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="1000"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="5000"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="10000"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="+Inf"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_sum{endpoint="WebAppWeb.Endpoint",event="test_event",handler="Elixir.Phoenix.LiveReloader.Socket"} 0.051792
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_count{endpoint="WebAppWeb.Endpoint",event="test_event",handler="Elixir.Phoenix.LiveReloader.Socket"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="another_test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="10"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="another_test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="100"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="another_test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="500"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="another_test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="1000"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="another_test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="5000"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="another_test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="10000"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="WebAppWeb.Endpoint",event="another_test_event",handler="Elixir.Phoenix.LiveReloader.Socket",le="+Inf"} 1
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_sum{endpoint="WebAppWeb.Endpoint",event="another_test_event",handler="Elixir.Phoenix.LiveReloader.Socket"} 0.051792
+web_app_prom_ex_phoenix_channel_handled_in_duration_milliseconds_count{endpoint="WebAppWeb.Endpoint",event="another_test_event",handler="Elixir.Phoenix.LiveReloader.Socket"} 1
 # HELP web_app_prom_ex_phoenix_http_requests_total The number of requests have been serviced.
 # TYPE web_app_prom_ex_phoenix_http_requests_total counter
 web_app_prom_ex_phoenix_http_requests_total{action="index",controller="Phoenix.LiveView.Plug",method="GET",path="/",status="500"} 2


### PR DESCRIPTION
### Change description

Adds the event name that is present  from the [`channel_handled_in` telemetry payload](https://hexdocs.pm/phoenix/Phoenix.Logger.html) as a tag for the duration metric. 

I also noticed that `:handler` was included in the `tags` field, but wasn't actually set under `tag_values`. Maybe this was a bug? I added it as a tag value as well.

There's a lot of value including this tag with duration metrics. Right now, if a specific event handler function is slow, there's no way to identify that with without the `event` dimension. With it added, it's now possible to group by events and monitor for slow handlers.
 
### Example usage

Nothing really required from the user's side to set this up, they'll just need to update their PromEx version. `channel_handled_in_duration_milliseconds` metrics will now include the `event` and `handler` tags. Example output:
```
phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="Server.Endpoint",event="select_elements",handler="Elixir.Server.UserSocket",le="10"} 1
phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="Server.Endpoint",event="select_elements",handler="Elixir.Server.UserSocket",le="100"} 1
phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="Server.Endpoint",event="select_elements",handler="Elixir.Server.UserSocket",le="500"} 1
phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="Server.Endpoint",event="select_elements",handler="Elixir.Server.UserSocket",le="1000"} 1
phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="Server.Endpoint",event="select_elements",handler="Elixir.Server.UserSocket",le="5000"} 1
phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="Server.Endpoint",event="select_elements",handler="Elixir.Server.UserSocket",le="10000"} 1
phoenix_channel_handled_in_duration_milliseconds_bucket{endpoint="Server.Endpoint",event="select_elements",handler="Elixir.Server.UserSocket",le="+Inf"} 1
phoenix_channel_handled_in_duration_milliseconds_sum{endpoint="Server.Endpoint",event="select_elements",handler="Elixir.Server.UserSocket"} 0.721542
phoenix_channel_handled_in_duration_milliseconds_count{endpoint="Server.Endpoint",event="select_elements",handler="Elixir.Server.UserSocket"} 1
```
### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
