### PR TITLE
Allow versions of telemetry newer than 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule PromEx.MixProject do
       # Required dependencies
       {:jason, "~> 1.2"},
       {:finch, "~> 0.13.0"},
-      {:telemetry, "~> 1.0"},
+      {:telemetry, ">= 1.0.0"},
       {:telemetry_poller, "~> 1.0"},
       {:telemetry_metrics, "~> 0.6"},
       {:telemetry_metrics_prometheus_core, "~> 1.0"},


### PR DESCRIPTION
### Change description

Change range of telemetry from `~> 1.0` to `>= 1.0.0` to allow for newer versions of `:telemetry` (currently `1.2.1` is the latest)

### What problem does this solve?

Issue number: #164 

### Example usage

### Additional details and screenshots

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
