### PR TITLE
Add supervisor start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ defmodule MyCoolApp.Application do
 
   def start(_type, _args) do
     children = [
+      MyAppWeb.Endpoint,
+      # PromEx should be started after the Endpoint, to avoid unnecessary error messages
       MyCoolApp.PromEx,
 
       ...


### PR DESCRIPTION
If you start PromEx before the Endpoint, it will raise an error `RuntimeError: ** (RuntimeError) could not find persistent term for endpoint` at least once, until the Endpoint started.

It works, but can pollute your logs (and will be very annoying if you have something like AppSignal running in production)

Issue number: #194 
