### PR TITLE
Fix typo in example plugin documentation

### DIFF
--- a/guides/howtos/Writing PromEx Plugins.md
+++ b/guides/howtos/Writing PromEx Plugins.md
@@ -44,7 +44,7 @@ defmodule MyApp.PromEx.Plugins.MyPhoenix do
           measurement: :duration,
           description: "The time it takes for the application to respond to HTTP requests.",
           reporter_options: [
-            buckets: exponential(1, 2, 12)
+            buckets: exponential!(1, 2, 12)
           ],
           tag_values: get_conn_tags(phoenix_router),
           tags: http_metrics_tags,


### PR DESCRIPTION
### Change description

Just a typo. The function name in the `reporter_options` is [exponential!](https://hexdocs.pm/prom_ex/PromEx.BucketGenerator.html#exponential!/3) (with a `!`).

### What problem does this solve?

Saves folks who copy/paste a few minutes of confusion 😄 

### Example usage

### Additional details and screenshots

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.