### PR TITLE
fix persistent-term issue on endpoint

### DIFF
--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -231,7 +231,6 @@ if Code.ensure_loaded?(Phoenix) do
         count, endpoint_module, endpoint_init_checker_function, otp_app when count < 10 ->
           case Process.whereis(endpoint_module) do
             pid when is_pid(pid) ->
-              IO.inspect(pid, label: "Endpoint PID")
               measurements = %{status: 1}
               url_metadata = %{url: endpoint_module.url(), endpoint: normalize_module_name(endpoint_module)}
               :telemetry.execute([:prom_ex, :plugin, :phoenix, :endpoint_url], measurements, url_metadata)


### PR DESCRIPTION
### Change description

Instead of using Process.sleep/1, 

- I used Phoenix.Endpoint.server?/2 to check if server already started
- If server started, but the process is not yet registered, retry again.

### What problem does this solve?

Issue number: (if applicable)

RuntimeError: could not find persistent term for endpoint __MODULE__. Make sure your endpoint is started and note you cannot access endpoint functions at compile-time

### Example usage

### Additional details and screenshots

### Checklist

- [ ] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
