### PR TITLE
makes the dashboard title configurable.

### DIFF
--- a/lib/prom_ex/dashboard_uploader.ex
+++ b/lib/prom_ex/dashboard_uploader.ex
@@ -88,7 +88,7 @@ defmodule PromEx.DashboardUploader do
     user_provided_assigns = prom_ex_module.dashboard_assigns()
     {apply_function, dashboard_opts} = Keyword.pop(dashboard_opts, :apply_function, fn dashboard -> dashboard end)
 
-    default_title =
+    default_title = Keyword.get(user_provided_assigns, :title) ||
       prom_ex_module.__otp_app__()
       |> Atom.to_string()
       |> Macro.camelize()


### PR DESCRIPTION
### Change description
This adds the configuration variable `title`to `dashboard_assigns`, making it possible to use a different name for the dashboard, other than MyProject.

### What problem does this solve?
I have multiple versions of the same codebase running, thus in my Grafana the Dashboards get overriden since they all have the same otp_name.

### Example usage

```elixir
  def dashboard_assigns do
    [
      datasource_id: PetalPro.config(:prometheus_datasource_id),
      default_selected_interval: "30s",
      title: "ainomaly.io"
    ]
  end
```
