### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule PromEx.MixProject do
       {:finch, "~> 0.15"},
       {:telemetry, ">= 1.0.0"},
       {:telemetry_poller, "~> 1.0"},
-      {:telemetry_metrics, "~> 1.0"},
+      {:telemetry_metrics, "~> 0.6 or ~> 1.0"},
       {:telemetry_metrics_prometheus_core, "~> 1.0"},
       {:plug_cowboy, "~> 2.5 or ~> 2.6"},
       {:octo_fetch, "~> 0.3"},

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule PromEx.MixProject do
       {:finch, "~> 0.15"},
       {:telemetry, ">= 1.0.0"},
       {:telemetry_poller, "~> 1.0"},
-      {:telemetry_metrics, "~> 0.6"},
+      {:telemetry_metrics, "~> 1.0"},
       {:telemetry_metrics_prometheus_core, "~> 1.0"},
       {:plug_cowboy, "~> 2.5 or ~> 2.6"},
       {:octo_fetch, "~> 0.3"},


### PR DESCRIPTION
bump telemetry metrics to 1.0

### Change description

### What problem does this solve?

version incompatibility


### Additional details and screenshots

No breaking changes from the upstream library. They just went 1.0. 

https://github.com/beam-telemetry/telemetry_metrics/blob/main/CHANGELOG.md
