### PR TITLE
Make plug_cowboy optional

### DIFF
--- a/lib/prom_ex.ex
+++ b/lib/prom_ex.ex
@@ -484,73 +484,79 @@ defmodule PromEx do
   end
 
   @doc false
-  def metrics_server_child_spec(acc, config, prom_ex_module, process_name) when is_map(config) do
-    transport_options = [num_acceptors: config.pool_size]
-    cowboy_opts = Keyword.drop(config.cowboy_opts, [:port, :transport_options])
+  if Code.ensure_loaded?(Plug.Cowboy) do
+    def metrics_server_child_spec(acc, config, prom_ex_module, process_name) when is_map(config) do
+      transport_options = [num_acceptors: config.pool_size]
+      cowboy_opts = Keyword.drop(config.cowboy_opts, [:port, :transport_options])
 
-    port =
-      case Map.fetch(config, :port) do
-        {:ok, port} when is_integer(port) ->
-          port
+      port =
+        case Map.fetch(config, :port) do
+          {:ok, port} when is_integer(port) ->
+            port
 
-        {:ok, port} when is_binary(port) ->
-          String.to_integer(port)
+          {:ok, port} when is_binary(port) ->
+            String.to_integer(port)
 
-        :error ->
-          raise "PromEx.MetricsServer requires a :port config value"
-      end
+          :error ->
+            raise "PromEx.MetricsServer requires a :port config value"
+        end
 
-    scheme =
-      config
-      |> Map.fetch(:protocol)
-      |> case do
-        {:ok, "http"} ->
-          :http
+      scheme =
+        config
+        |> Map.fetch(:protocol)
+        |> case do
+          {:ok, "http"} ->
+            :http
 
-        {:ok, "https"} ->
-          :https
+          {:ok, "https"} ->
+            :https
 
-        {:ok, :http} ->
-          :http
+          {:ok, :http} ->
+            :http
 
-        {:ok, :https} ->
-          :https
+          {:ok, :https} ->
+            :https
 
-        :error ->
-          raise "PromEx.MetricsServer requires a :protocol config value of :http or :https"
+          :error ->
+            raise "PromEx.MetricsServer requires a :protocol config value of :http or :https"
 
-        _ ->
-          raise "Invalid :protocol config value provided to PromEx.MetricsServer (valid values are :http and :https)"
-      end
+          _ ->
+            raise "Invalid :protocol config value provided to PromEx.MetricsServer (valid values are :http and :https)"
+        end
 
-    plug_opts = %{
-      path: config.path,
-      prom_ex_module: prom_ex_module,
-      auth_strategy: Map.get(config, :auth_strategy),
-      auth_token: Map.get(config, :auth_token),
-      auth_user: Map.get(config, :auth_user),
-      auth_password: Map.get(config, :auth_password)
-    }
+      plug_opts = %{
+        path: config.path,
+        prom_ex_module: prom_ex_module,
+        auth_strategy: Map.get(config, :auth_strategy),
+        auth_token: Map.get(config, :auth_token),
+        auth_user: Map.get(config, :auth_user),
+        auth_password: Map.get(config, :auth_password)
+      }
 
-    plug_definition = {PromEx.MetricsServer.Plug, plug_opts}
+      plug_definition = {PromEx.MetricsServer.Plug, plug_opts}
 
-    spec =
-      Plug.Cowboy.child_spec(
-        ref: process_name,
-        scheme: scheme,
-        plug: plug_definition,
-        options: [{:port, port}, {:transport_options, transport_options} | cowboy_opts]
+      spec =
+        Plug.Cowboy.child_spec(
+          ref: process_name,
+          scheme: scheme,
+          plug: plug_definition,
+          options: [{:port, port}, {:transport_options, transport_options} | cowboy_opts]
+        )
+
+      Logger.info(
+        "PromEx is starting a standalone metrics server on port #{inspect(port)} over #{Atom.to_string(scheme)}"
       )
 
-    Logger.info(
-      "PromEx is starting a standalone metrics server on port #{inspect(port)} over #{Atom.to_string(scheme)}"
-    )
+      [spec | acc]
+    end
 
-    [spec | acc]
-  end
-
-  def metrics_server_child_spec(acc, :disabled, _prom_ex_module, _process_name) do
-    acc
+    def metrics_server_child_spec(acc, :disabled, _prom_ex_module, _process_name) do
+      acc
+    end
+  else
+    def metrics_server_child_spec(acc, _, _prom_ex_module, _process_name) do
+      acc
+    end
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule PromEx.MixProject do
       {:telemetry_poller, "~> 1.0"},
       {:telemetry_metrics, "~> 0.6 or ~> 1.0"},
       {:telemetry_metrics_prometheus_core, "~> 1.0"},
-      {:plug_cowboy, "~> 2.5 or ~> 2.6"},
+      {:plug_cowboy, "~> 2.5 or ~> 2.6", optional: true},
       {:octo_fetch, "~> 0.3"},
 
       # Optional dependencies depending on what telemetry events the user is interested in capturing


### PR DESCRIPTION
Hi 👋

With this PR, we can serve metrics in a different way, for instance using Bandit server with PromEx.Plug.

### What problem does this solve?

With this change, the system doesn't need to have plug_cowboy and related dependencies just for PromEx.

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.

Struggling a bit with the local environment for prom_ex now, could make it run in a local project.