### PR TITLE
ft: implement pluggable storage

### DIFF
--- a/lib/prom_ex/storage.ex
+++ b/lib/prom_ex/storage.ex
@@ -1,0 +1,20 @@
+defmodule PromEx.Storage do
+  @moduledoc """
+  Storage definition behaviour.
+  """
+
+  @doc """
+  Gather metrics for given collector with given `name`.
+  """
+  @callback scrape(name :: atom()) :: iodata() | :prom_ex_down
+
+  @doc """
+  Define child specs for gatherer process.
+  """
+  @callback child_spec(atom(), Telemetry.Metrics.metrics()) :: Supervisor.child_spec()
+
+  def scrape(mod, name), do: mod.scrape(name)
+
+  def child_spec(mod, name, metrics),
+    do: mod.child_spec(name, metrics)
+end

--- a/lib/prom_ex/storage/core.ex
+++ b/lib/prom_ex/storage/core.ex
@@ -1,0 +1,25 @@
+defmodule PromEx.Storage.Core do
+  @behaviour PromEx.Storage
+
+  alias TelemetryMetricsPrometheus.Core
+
+  @impl true
+  def scrape(name) do
+    if Process.whereis(name),
+      do: Core.scrape(name),
+      else: :prom_ex_down
+  end
+
+  @impl true
+  def child_spec(name, metrics) do
+    opts = [
+      name: name,
+      metrics: metrics,
+      require_seconds: false,
+      consistent_units: true,
+      start_async: false
+    ]
+
+    Core.child_spec(opts)
+  end
+end


### PR DESCRIPTION
### Change description

Preliminary work for supporting different storages beyond `telemetry_metrics_prometheus_core`.

### What problem does this solve?

Support implementing alternative storage backends (like [Peep][]) for users that require different performance characteristics.

[Peep]: https://github.com/rkallos/peep

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [ ] My changes have passed unit tests and have been tested E2E in an example project.
