### PR TITLE
Add link to conditional plug invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ There are a couple of solutions to this problem:
    maintain in order to only execute the `PromEx.Plug` plug when the incoming request fulfills your configured
    requirements (see the [PromEx.Plug HexDocs](https://hexdocs.pm/prom_ex/1.1.1/PromEx.Plug.html) for an example).
 
+3. If Unplug doesn't suit your needs, you can invoke `PromEx.Plug`
+   [conditionally with your own logic](https://hexdocs.pm/plug/1.16.1/Plug.Builder.html#module-conditional-plugs).
+
 ## Performance Concerns
 
 You may think to yourself that with all these metrics being collected and scraped, that the performance of your


### PR DESCRIPTION
### Change description
Minor docs update! I think `Plug` added this functionality late last year.

### What problem does this solve?
`Unplug` is awesome, but I needed to conditionally check a few headers in ways that weren't obvious with that library. It's also nice to add one less library.

### Example usage
```elixir
  plug :metrics

  defp metrics(%Plug.Conn{} = conn, _opts) do
    bearer_string = "Bearer #{Application.get_env(:my_app, MyApp.PromEx)[:bearer_token]}"

    if conn.request_path == "/metrics" &&
         Plug.Conn.get_req_header(conn, "authorization")
         |> Enum.any?(fn i ->
           i == bearer_string
         end) do
      PromEx.Plug.call(conn, %{metrics_path: "/metrics", prom_ex_module: MyApp.PromEx})
    else
      conn
    end
  end
```

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
