### PR TITLE
Include zeros for missing queue states in Oban polling metrics

### DIFF
--- a/lib/prom_ex/plugins/oban.ex
+++ b/lib/prom_ex/plugins/oban.ex
@@ -448,7 +448,7 @@ if Code.ensure_loaded?(Oban) do
       all_queues = Keyword.keys(Oban.config().queues)
       all_states = Oban.Job.states()
 
-      zeros = for queue <- all_queues, state <- all_states, into: %{}, do: {{queue, state}, 0}
+      zeros = for queue <- all_queues, state <- all_states, into: %{}, do: {{to_string(queue), to_string(state)}, 0}
       counts = for {queue, state, count} <- query_result, into: %{}, do: {{queue, state}, count}
 
       Map.merge(zeros, counts)


### PR DESCRIPTION
### Change description

This changes Oban polling metrics to include zeros for all missing queue + state combinations in the Oban jobs table. Queues are taken from the Oban config, and Oban exposes all possible states in `Oban.Job.states/0`.

### What problem does this solve?

The polling query will only count jobs that exist in the table, so naturally no zeros will be returned. When counts for a particular queue state combination is present and then disappears from one poll to the next, some tools will show the stale last-seen count, when the true count is zero. A spike in available or executing jobs that is quickly processed can lead to a misleading count hanging around.

My team at work had this issue, and we're running a copy of the Oban plugin for now, with these changes.

A possible downside of this change is a larger metrics payload, in cases with a lot of mostly-empty queues. We only have 5 fairly busy queues.

Issue number: #202 

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.

Sorry about the absence of tests. It looked like adding tests for this would be fairly invasive in the current test suite.