### PR TITLE
Pass along new polling_opts

### DIFF
--- a/lib/prom_ex/plugins/oban.ex
+++ b/lib/prom_ex/plugins/oban.ex
@@ -97,6 +97,8 @@ if Code.ensure_loaded?(Oban) do
 
       oban_supervisors = get_oban_supervisors(opts)
 
+      polling_opts = Keyword.get(opts, :opts, [])
+
       # Queue length details
       Polling.build(
         :oban_queue_poll_metrics,
@@ -110,7 +112,8 @@ if Code.ensure_loaded?(Oban) do
             measurement: :count,
             tags: [:name, :queue, :state]
           )
-        ]
+        ],
+        polling_opts
       )
     end
 


### PR DESCRIPTION
The newly added opts for Polling.build/5 are not passed from the Oban plugin when called like so: 
```
{Plugins.Oban, oban_supervisors: [Oban], poll_rate: 10_000, opts: [detach_on_error: false]}
```

https://github.com/akoutmos/prom_ex/issues/236
https://github.com/akoutmos/prom_ex/commit/3feecebb979ac4b46f8326f45b1e699ad550673e