### PR TITLE
Phoenix Plugin: Correctly support multiple endpoints

### DIFF
--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -251,7 +251,7 @@ if Code.ensure_loaded?(Phoenix) do
         end
 
       %{
-        endpoint: module,
+        endpoint: normalize_module_name(module),
         url: module.url(),
         port: port
       }

--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -346,7 +346,7 @@ if Code.ensure_loaded?(Phoenix) do
               %{
                 endpoint: normalize_module_name(endpoint),
                 event: normalize_event_name.(event),
-                handler: handler
+                handler: normalize_module_name(handler)
               }
             end,
             tags: [:endpoint, :handler, :event],

--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -189,9 +189,9 @@ if Code.ensure_loaded?(Phoenix) do
     end
 
     defp endpoint_info(metric_prefix, opts) do
-      # Fetch user options
-      phoenix_endpoint = Keyword.get(opts, :endpoint) || Keyword.get(opts, :endpoints)
-      keep_function_filter = keep_endpoint_metrics(phoenix_endpoint)
+      phoenix_endpoints = normalize_endpoint(opts)
+
+      keep_function_filter = keep_endpoint_metrics(phoenix_endpoints)
 
       Event.build(
         :phoenix_endpoint_metrics,
@@ -218,8 +218,17 @@ if Code.ensure_loaded?(Phoenix) do
       )
     end
 
-    defp keep_endpoint_metrics(phoenix_endpoint) when is_atom(phoenix_endpoint) do
-      keep_endpoint_metrics([phoenix_endpoint])
+    defp normalize_endpoint(opts) do
+      cond do
+        endpoint = Keyword.get(opts, :endpoint) ->
+          [endpoint]
+
+        endpoints = Keyword.get(opts, :endpoints) ->
+          Enum.map(endpoints, fn e -> elem(e, 0) end)
+
+        true ->
+          []
+      end
     end
 
     defp keep_endpoint_metrics(phoenix_endpoints) do


### PR DESCRIPTION
### Change description

The current logic for the `keep_endpoint_metrics` function doesn't work for cases where multiple endpoints are configured using the `endpoints:` key.

This change normalizes the endpoints config to work with `module in phoenix_endpoints`

### What problem does this solve?

The events defined in the `endpoint_info` function weren't working as expected, as the `keep_function_filter` returned false. This started happening after I tested out the config for multiple endpoints.

### Checklist

- [x] My changes have passed unit tests and have been tested E2E in an example project.
