### PR TITLE
Allow additional (custom) tags in HTTP events

### DIFF
--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -35,6 +35,15 @@ if Code.ensure_loaded?(Phoenix) do
       will be set to `some-route`. You can pass in either a regular expression or a string to match the incoming
       request.
 
+    - `additional_tags`: This option is OPTIONAL and allows you to specify additional tags (as a list of atoms) to be
+      added to the HTTP metrics. This is useful if you want to add additional context to your metrics. The additional
+      tag values will be taken from the private key `:prom_ex` on the connection struct, which should be a map.
+      Defaults to `[]`.
+
+      For example, if you want to report the authentication status of the request, you can set
+      `additional_tags: [:authenticated]` and use `PromEx.Plugins.Phoenix.put_metadata(conn, :authenticated, true)`
+      in a controller or plug to add the tag to the metrics.
+
     - `normalize_event_name`: This option is OPTIONAL and allows you to remap the channel event names to a different
       name. This is useful if you want to limit the number or size of event names that are emitted.
 
@@ -76,6 +85,15 @@ if Code.ensure_loaded?(Phoenix) do
 
         - `:additional_routes`: This option is OPTIONAL and allows you to specify route path labels for applications routes
         not defined in your Router modules for the corresponding endpoint.
+
+        - `additional_tags`: This option is OPTIONAL and allows you to specify additional tags (as a list of atoms) to be
+          added to the HTTP metrics. This is useful if you want to add additional context to your metrics. The additional
+          tag values will be taken from the private key `:prom_ex` on the connection struct, which should be a map.
+          Defaults to `[]`.
+
+          For example, if you want to report the authentication status of the request, you can set
+          `additional_tags: [:authenticated]` and use `PromEx.Plugins.Phoenix.put_metadata(conn, :authenticated, true)`
+          in a controller or plug to add the tag to the metrics.
 
     #### Example plugin configuration
 
@@ -261,6 +279,7 @@ if Code.ensure_loaded?(Phoenix) do
     defp http_events(metric_prefix, opts) do
       routers = fetch_routers!(opts)
       additional_routes = fetch_additional_routes!(opts)
+      additional_tags = fetch_additional_tags!(opts)
       http_metrics_tags = [:status, :method, :path, :controller, :action, :host]
       duration_unit = Keyword.get(opts, :duration_unit, :millisecond)
       duration_unit_plural = Utils.make_plural_atom(duration_unit)
@@ -277,8 +296,8 @@ if Code.ensure_loaded?(Phoenix) do
             reporter_options: [
               buckets: [10, 100, 500, 1_000, 5_000, 10_000, 30_000]
             ],
-            tag_values: get_conn_tags(routers, additional_routes),
-            tags: http_metrics_tags,
+            tag_values: get_conn_tags(routers, additional_routes, additional_tags),
+            tags: http_metrics_tags ++ additional_tags,
             unit: {:native, duration_unit}
           ),
 
@@ -296,8 +315,8 @@ if Code.ensure_loaded?(Phoenix) do
                 _ -> :erlang.iolist_size(metadata.conn.resp_body)
               end
             end,
-            tag_values: get_conn_tags(routers, additional_routes),
-            tags: http_metrics_tags,
+            tag_values: get_conn_tags(routers, additional_routes, additional_tags),
+            tags: http_metrics_tags ++ additional_tags,
             unit: :byte
           ),
 
@@ -306,8 +325,8 @@ if Code.ensure_loaded?(Phoenix) do
             metric_prefix ++ [:http, :requests, :total],
             event_name: @stop_event,
             description: "The number of requests have been serviced.",
-            tag_values: get_conn_tags(routers, additional_routes),
-            tags: http_metrics_tags
+            tag_values: get_conn_tags(routers, additional_routes, additional_tags),
+            tags: http_metrics_tags ++ additional_tags
           )
         ]
       )
@@ -386,14 +405,21 @@ if Code.ensure_loaded?(Phoenix) do
       )
     end
 
-    defp get_conn_tags(routers, []) do
+    defp get_conn_tags(routers, additional_routes, additional_tags) do
       fn
         %{conn: %Conn{} = conn} ->
-          default_route_tags = %{
-            path: "Unknown",
-            controller: "Unknown",
-            action: "Unknown"
-          }
+          default_route_tags =
+            case additional_routes do
+              [] ->
+                %{
+                  path: "Unknown",
+                  controller: "Unknown",
+                  action: "Unknown"
+                }
+
+              additional_routes ->
+                handle_additional_routes_check(conn, additional_routes)
+            end
 
           conn
           |> do_get_router_info(routers, default_route_tags)
@@ -402,27 +428,11 @@ if Code.ensure_loaded?(Phoenix) do
             method: conn.method,
             host: conn.host
           })
+          |> do_get_additional_tags(conn, additional_tags)
 
         _ ->
           Logger.warning("Could not resolve path for request")
-      end
-    end
-
-    defp get_conn_tags(routers, additional_routes) do
-      fn
-        %{conn: %Conn{} = conn} ->
-          default_route_tags = handle_additional_routes_check(conn, additional_routes)
-
-          conn
-          |> do_get_router_info(routers, default_route_tags)
-          |> Map.merge(%{
-            status: conn.status,
-            method: conn.method,
-            host: conn.host
-          })
-
-        _ ->
-          Logger.warning("Could not resolve path for request")
+          %{}
       end
     end
 
@@ -470,6 +480,12 @@ if Code.ensure_loaded?(Phoenix) do
           true ->
             false
         end
+      end)
+    end
+
+    defp do_get_additional_tags(tag_map, conn, additional_tags) do
+      Enum.reduce(additional_tags, tag_map, fn tag, acc ->
+        Map.put(acc, tag, conn.private[:prom_ex][tag])
       end)
     end
 
@@ -523,6 +539,24 @@ if Code.ensure_loaded?(Phoenix) do
       end
     end
 
+    defp fetch_additional_tags!(opts) do
+      opts
+      |> fetch_either!(:router, :endpoints)
+      |> case do
+        endpoints when is_list(endpoints) ->
+          endpoints
+          |> Enum.flat_map(fn
+            {_endpoint, endpoint_opts} ->
+              Keyword.get(endpoint_opts, :additional_tags, [])
+          end)
+          |> MapSet.new()
+          |> MapSet.to_list()
+
+        _router ->
+          Keyword.get(opts, :additional_tags, [])
+      end
+    end
+
     defp fetch_event_prefixes!(opts) do
       opts
       |> fetch_either!(:router, :endpoints)
@@ -572,6 +606,19 @@ if Code.ensure_loaded?(Phoenix) do
           raise KeyError, "Neither #{inspect(key1)} nor #{inspect(key2)} found in #{inspect(keywordlist)}"
       end
     end
+
+    @doc """
+    This function is used to put additional metadata on the connection struct. This is useful if you want to add
+    additional context to your metrics. In order for the additional metadata to be included as a tag in the HTTP
+    metrics, you must include the `key` in the `additional_tags` option in the plugin configuration.
+    """
+    def put_metadata(conn, key, value) do
+      metadata =
+        Map.get(conn.private, :prom_ex, %{})
+        |> Map.put(key, value)
+
+      Plug.Conn.put_private(conn, :prom_ex, metadata)
+    end
   end
 else
   defmodule PromEx.Plugins.Phoenix do
@@ -580,6 +627,10 @@ else
 
     @impl true
     def event_metrics(_opts) do
+      PromEx.Plugin.no_dep_raise(__MODULE__, "Phoenix")
+    end
+
+    def put_metadata(conn, key, value) do
       PromEx.Plugin.no_dep_raise(__MODULE__, "Phoenix")
     end
   end

--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -37,11 +37,10 @@ if Code.ensure_loaded?(Phoenix) do
 
     - `additional_tags`: This option is OPTIONAL and allows you to specify additional tags (as a list of atoms) to be
       added to the HTTP metrics. This is useful if you want to add additional context to your metrics. The additional
-      tag values will be taken from the private key `:prom_ex` on the connection struct, which should be a map.
-      Defaults to `[]`.
+      tag values will be taken from the private key `:prom_ex_[tag]` on the connection struct. Defaults to `[]`.
 
       For example, if you want to report the authentication status of the request, you can set
-      `additional_tags: [:authenticated]` and use `PromEx.Plugins.Phoenix.put_metadata(conn, :authenticated, true)`
+      `additional_tags: [:authenticated]` and use `Plug.Conn.put_private(conn, :prom_ex_authenticated, true)`
       in a controller or plug to add the tag to the metrics.
 
     - `normalize_event_name`: This option is OPTIONAL and allows you to remap the channel event names to a different
@@ -88,11 +87,10 @@ if Code.ensure_loaded?(Phoenix) do
 
         - `additional_tags`: This option is OPTIONAL and allows you to specify additional tags (as a list of atoms) to be
           added to the HTTP metrics. This is useful if you want to add additional context to your metrics. The additional
-          tag values will be taken from the private key `:prom_ex` on the connection struct, which should be a map.
-          Defaults to `[]`.
+          tag values will be taken from the private key `:prom_ex_[tag]` on the connection struct. Defaults to `[]`.
 
           For example, if you want to report the authentication status of the request, you can set
-          `additional_tags: [:authenticated]` and use `PromEx.Plugins.Phoenix.put_metadata(conn, :authenticated, true)`
+          `additional_tags: [:authenticated]` and use `Plug.Conn.put_private(conn, :prom_ex_authenticated, true)`
           in a controller or plug to add the tag to the metrics.
 
     #### Example plugin configuration
@@ -485,7 +483,7 @@ if Code.ensure_loaded?(Phoenix) do
 
     defp do_get_additional_tags(tag_map, conn, additional_tags) do
       Enum.reduce(additional_tags, tag_map, fn tag, acc ->
-        Map.put(acc, tag, conn.private[:prom_ex][tag])
+        Map.put(acc, tag, conn.private[:"prom_ex_#{tag}"])
       end)
     end
 
@@ -606,19 +604,6 @@ if Code.ensure_loaded?(Phoenix) do
           raise KeyError, "Neither #{inspect(key1)} nor #{inspect(key2)} found in #{inspect(keywordlist)}"
       end
     end
-
-    @doc """
-    This function is used to put additional metadata on the connection struct. This is useful if you want to add
-    additional context to your metrics. In order for the additional metadata to be included as a tag in the HTTP
-    metrics, you must include the `key` in the `additional_tags` option in the plugin configuration.
-    """
-    def put_metadata(conn, key, value) do
-      metadata =
-        Map.get(conn.private, :prom_ex, %{})
-        |> Map.put(key, value)
-
-      Plug.Conn.put_private(conn, :prom_ex, metadata)
-    end
   end
 else
   defmodule PromEx.Plugins.Phoenix do
@@ -627,10 +612,6 @@ else
 
     @impl true
     def event_metrics(_opts) do
-      PromEx.Plugin.no_dep_raise(__MODULE__, "Phoenix")
-    end
-
-    def put_metadata(conn, key, value) do
       PromEx.Plugin.no_dep_raise(__MODULE__, "Phoenix")
     end
   end

--- a/test/prom_ex/plugins/phoenix_test.exs
+++ b/test/prom_ex/plugins/phoenix_test.exs
@@ -59,6 +59,26 @@ defmodule PromEx.Plugins.PhoenixTest do
     end
   end
 
+  defmodule WebApp.PromExSingleEndpointAdditionalTags do
+    use PromEx, otp_app: :web_app
+
+    @additional_routes [
+      special_label: "/really-cool-route",
+      another_label: ~r(\/another-cool-route)
+    ]
+
+    @impl true
+    def plugins do
+      [
+        {Phoenix,
+         router: TestApp.Router,
+         additional_routes: @additional_routes,
+         endpoint: TestApp.Endpoint,
+         additional_tags: [:my_metadata]}
+      ]
+    end
+  end
+
   test "telemetry events are accumulated for single endpoint configuration" do
     start_supervised!(WebApp.PromExSingleEndpoint)
     Events.execute_all(:phoenix)
@@ -80,6 +100,16 @@ defmodule PromEx.Plugins.PhoenixTest do
     collected_metrics = Metrics.read_collected(WebApp.PromExSingleEndpointNormalizedChannelEvents)
 
     assert collected_metrics |> Enum.any?(&String.contains?(&1, "unknown"))
+  end
+
+  test "telemetry events include additional tags" do
+    start_supervised!(WebApp.PromExSingleEndpointAdditionalTags)
+    Events.execute_all(:phoenix)
+
+    collected_metrics = Metrics.read_collected(WebApp.PromExSingleEndpointAdditionalTags)
+
+    assert collected_metrics |> Enum.any?(&String.contains?(&1, "my_metadata=\"test\""))
+    refute collected_metrics |> Enum.any?(&String.contains?(&1, "non_collected_metadata=\"test\""))
   end
 
   describe "event_metrics/1" do

--- a/test/support/events/phoenix.exs
+++ b/test/support/events/phoenix.exs
@@ -3077,7 +3077,8 @@
         private: %{
           phoenix_endpoint: WebAppWeb.Endpoint,
           phoenix_request_logger: {"request_logger", "request_logger"},
-          prom_ex: %{my_metadata: "test", non_collected_metadata: "test"}
+          prom_ex_my_metadata: "test",
+          prom_ex_non_collected_metadata: "test"
         },
         query_params: %{},
         query_string: "",

--- a/test/support/events/phoenix.exs
+++ b/test/support/events/phoenix.exs
@@ -3076,7 +3076,8 @@
         port: 4000,
         private: %{
           phoenix_endpoint: WebAppWeb.Endpoint,
-          phoenix_request_logger: {"request_logger", "request_logger"}
+          phoenix_request_logger: {"request_logger", "request_logger"},
+          prom_ex: %{my_metadata: "test", non_collected_metadata: "test"}
         },
         query_params: %{},
         query_string: "",


### PR DESCRIPTION
### Change description

This PR allows users of the library to define `additional_tags` that should be included in HTTP metrics from the Phoenix plugin.

### What problem does this solve?

Folks may wish to tag HTTP events with information other than the default tags (status, route, etc.). For example, someone might want to tag events with `authenticated="true"` based on the authentication status of the request. While this kind of custom tagging can be abused, when used well, it can greatly improve one's ability to query the collected data.

### Example usage

First, configure the Phoenix plugin to look for additional tags:

```elixir
def plugins do
  [
    {PromEx.Plugins.Phoenix,
     router: MyApp.Router,
     endpoint: MyApp.Endpoint,
     additional_tags: [:authenticated]}
  ]
end
```

Then, set data in the connection struct's private data using a matching prefixed key:

```elixir
# Authentication Plug
def call(conn, opts) do
  # ...
  Plug.Conn.put_private(conn, :prom_ex_authenticated, true)
end
```

### Additional details and screenshots

I initially implemented this PR in a way that required additional tags to be stored in a nested `:prom_ex` map in the private connection data (you can see the first commit for that version). This made it difficult to store metadata, however, because callers would have to check for the existence of the `:prom_ex` map and either create it or merge data into it as appropriate. Using top-level interpolated keys solves this issue while still preventing naming collisions with other private data.

### Checklist

- [x] I have added unit tests to cover my changes.
- [x] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
