### PR TITLE
fix: use oban name to retrieve config

### DIFF
--- a/lib/prom_ex/plugins/oban.ex
+++ b/lib/prom_ex/plugins/oban.ex
@@ -438,7 +438,7 @@ if Code.ensure_loaded?(Oban) do
 
       config
       |> Oban.Repo.all(query)
-      |> include_zeros_for_missing_queue_states()
+      |> include_zeros_for_missing_queue_states(config)
       |> Enum.each(fn {{queue, state}, count} ->
         measurements = %{count: count}
         metadata = %{name: normalize_module_name(oban_supervisor), queue: queue, state: state}
@@ -447,10 +447,10 @@ if Code.ensure_loaded?(Oban) do
       end)
     end
 
-    defp include_zeros_for_missing_queue_states(query_result) do
+    defp include_zeros_for_missing_queue_states(query_result, config) do
       {_, opts} =
-        Oban.config().plugins
-        |> Enum.find({nil, [queues: Oban.config().queues]}, fn {plugin, _} ->
+        Oban.config(config.name).plugins
+        |> Enum.find({nil, [queues: Oban.config(config.name).queues]}, fn {plugin, _} ->
           plugin == Oban.Pro.Plugins.DynamicQueues
         end)
 


### PR DESCRIPTION
### Change description

Retrieve Oban's config with the correct name

### What problem does this solve?

Setting up an Oban instance with a custom name like this:

```elixir
config :my_app, Oban,
  name: MyCustom.Oban,
  repo: MyApp.Repo,
  queues: [default: 10]
```

results in the following error

```
16:09:42.585 [error] Error when calling MFA defined by measurement: PromEx.Plugins.Oban :execute_queue_metrics [MapSet.new([MyCustom.Oban])]
Class=:error
Reason=%RuntimeError{
  message: "No Oban instance named `Oban` is running and config isn't available.\n"
}
Stacktrace=[
  {Oban.Registry, :config, 1, [file: ~c"lib/oban/registry.ex", line: 37]},
  {PromEx.Plugins.Oban, :include_zeros_for_missing_queue_states, 1,
   [file: ~c"lib/prom_ex/plugins/oban.ex", line: 454]},
  {PromEx.Plugins.Oban, :handle_oban_queue_polling_metrics, 2,
   [file: ~c"lib/prom_ex/plugins/oban.ex", line: 443]},
  {Enum, :"-each/2-fun-0-", 3, [file: ~c"lib/enum.ex", line: 992]},
  {Enum, :"-each/2-anonymous-3-", 3, [file: ~c"lib/enum.ex", line: 4511]},
  {Enumerable.List, :reduce, 3, [file: ~c"lib/enum.ex", line: 4964]},
  {Enum, :each, 2, [file: ~c"lib/enum.ex", line: 4511]},
  {:telemetry_poller, :make_measurement, 1,
   [
     file: ~c"/Users/ale/workspace/customoban/deps/telemetry_poller/src/telemetry_poller.erl",
     line: 336
   ]}
]
```
