### PR TITLE
Remove unnecessary `IO.iodata_to_binary/1`

### DIFF
--- a/lib/prom_ex/storage/peep.ex
+++ b/lib/prom_ex/storage/peep.ex
@@ -10,7 +10,6 @@ defmodule PromEx.Storage.Peep do
   def scrape(name) do
     Peep.get_all_metrics(name)
     |> Peep.Prometheus.export()
-    |> IO.iodata_to_binary()
   end
 
   @impl true


### PR DESCRIPTION
### Change description

The Storage behaviour expects iodata, so there's no need to convert the data
to binary.

### What problem does this solve?

None. Just improves performance.

Issue number: none.

### Example usage

Not applicable.

### Additional details and screenshots

Not applicable.

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [X] My changes have passed unit tests and have been tested E2E in an example project.
