### PR TITLE
fix: Use correct legend for Atom Table Size panel in BEAM Grafana dashboard

### DIFF
--- a/priv/beam.json.eex
+++ b/priv/beam.json.eex
@@ -1844,7 +1844,7 @@
         {
           "expr": "<%= @beam_metric_prefix %>_stats_atom_count{job=\"$job\", instance=\"$instance\"}",
           "interval": "",
-          "legendFormat": "Active ports",
+          "legendFormat": "Active Atoms",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
### Change description

Update the legend for the "Atom Table Size" panel of the BEAM Grafana dashboard to "Active Atoms" from "Active ports" 

### What problem does this solve?

The legend is incorrect; it belongs to the "Active Ports" panel. This panel is for atoms.

### Example usage

### Additional details and screenshots

<img width="1432" height="1192" alt="CleanShot 2025-07-28 at 07 02 01@2x" src="https://github.com/user-attachments/assets/6f989a97-1620-4100-9aba-6fca1a7b4335" />
