### PR TITLE
Fix config oban plugin

### DIFF
--- a/lib/prom_ex/plugins/oban.ex
+++ b/lib/prom_ex/plugins/oban.ex
@@ -438,7 +438,7 @@ if Code.ensure_loaded?(Oban) do
 
       config
       |> Oban.Repo.all(query)
-      |> include_zeros_for_missing_queue_states()
+      |> include_zeros_for_missing_queue_states(config)
       |> Enum.each(fn {{queue, state}, count} ->
         measurements = %{count: count}
         metadata = %{name: normalize_module_name(oban_supervisor), queue: queue, state: state}
@@ -447,10 +447,10 @@ if Code.ensure_loaded?(Oban) do
       end)
     end
 
-    defp include_zeros_for_missing_queue_states(query_result) do
+    defp include_zeros_for_missing_queue_states(query_result, config) do
       {_, opts} =
-        Oban.config().plugins
-        |> Enum.find({nil, [queues: Oban.config().queues]}, fn {plugin, _} ->
+        config.plugins
+        |> Enum.find({nil, [queues: config.queues]}, fn {plugin, _} ->
           plugin == Oban.Pro.Plugins.DynamicQueues
         end)
 

--- a/test/prom_ex/plugins/oban_test.exs
+++ b/test/prom_ex/plugins/oban_test.exs
@@ -14,12 +14,50 @@ defmodule PromEx.Plugins.ObanTest do
     end
   end
 
+  defmodule MultiObanApp.PromEx do
+    use PromEx, otp_app: :multi_oban_app
+
+    @impl true
+    def plugins do
+      [{PromEx.Plugins.Oban, oban_supervisors: [Oban, Oban.SuperSecret]}]
+    end
+  end
+
   test "telemetry events are accumulated" do
     start_supervised!(WebApp.PromEx)
 
     Events.execute_all(:oban)
 
     Metrics.assert_prom_ex_metrics(WebApp.PromEx, :oban)
+  end
+
+  test "telemetry events are accumulated for multiple Oban instances" do
+    start_supervised!(MultiObanApp.PromEx)
+
+    Events.execute_all(:oban)
+
+    collected_metrics = MultiObanApp.PromEx |> PromEx.get_metrics() |> String.split("\n", trim: true)
+
+    assert Enum.any?(collected_metrics, fn line ->
+             String.contains?(line, ~s(name="Oban")) and String.contains?(line, ~s(queue="default"))
+           end)
+
+    assert Enum.any?(collected_metrics, fn line ->
+             String.contains?(line, ~s(name="Oban.SuperSecret")) and
+               String.contains?(line, ~s(queue="default"))
+           end)
+
+    assert Enum.any?(collected_metrics, fn line ->
+             String.contains?(line, ~s(name="Oban")) and
+               String.contains?(line, ~s(queue="events")) and
+               String.contains?(line, "25")
+           end)
+
+    assert Enum.any?(collected_metrics, fn line ->
+             String.contains?(line, ~s(name="Oban.SuperSecret")) and
+               String.contains?(line, ~s(queue="events")) and
+               String.contains?(line, "50")
+           end)
   end
 
   describe "event_metrics/1" do
@@ -31,6 +69,21 @@ defmodule PromEx.Plugins.ObanTest do
   describe "polling_metrics/1" do
     test "should return the correct number of metrics" do
       assert %Polling{} = ObanPlugin.polling_metrics(otp_app: :prom_ex)
+    end
+
+    test "works with multiple Oban instances with different queue configurations" do
+      polling_metrics =
+        ObanPlugin.polling_metrics(
+          otp_app: :prom_ex,
+          oban_supervisors: [Oban, Oban.SuperSecret]
+        )
+
+      assert %Polling{} = polling_metrics
+
+      assert {PromEx.Plugins.Oban, :execute_queue_metrics, [supervisors]} =
+               polling_metrics.measurements_mfa
+
+      assert MapSet.equal?(MapSet.new(supervisors), MapSet.new([Oban, Oban.SuperSecret]))
     end
   end
 


### PR DESCRIPTION
### Change description

### What problem does this solve?

When using multiple Oban instances or custom Oban instance names, the plugin is not able to fetch the Oban config because it is hard-coded for the default Oban instance name.

Issue number: (if applicable)

### Example usage

There are tests included.

### Additional details and screenshots

### Checklist

- [x] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
