### PR TITLE
Keep options order in Phoenix plugin

### DIFF
--- a/example_applications/web_app/lib/web_app/recorder_supervisor.ex
+++ b/example_applications/web_app/lib/web_app/recorder_supervisor.ex
@@ -22,8 +22,7 @@ defmodule WebApp.RecorderSupervisor do
         :polling_metrics
       ]
       |> Enum.flat_map(&get_metrics(module, &1, args))
-      |> MapSet.new()
-      |> MapSet.to_list()
+      |> Enum.uniq()
 
     name = Module.concat(module, Recorder)
 

--- a/lib/prom_ex/plugins/phoenix.ex
+++ b/lib/prom_ex/plugins/phoenix.ex
@@ -515,8 +515,7 @@ if Code.ensure_loaded?(Phoenix) do
             {_endpoint, endpoint_opts} ->
               Keyword.get(endpoint_opts, :additional_routes, [])
           end)
-          |> MapSet.new()
-          |> MapSet.to_list()
+          |> Enum.uniq()
 
         _router ->
           Keyword.get(opts, :additional_routes, [])
@@ -537,8 +536,7 @@ if Code.ensure_loaded?(Phoenix) do
         _router ->
           [Keyword.get(opts, :event_prefix, [:phoenix, :endpoint])]
       end
-      |> MapSet.new()
-      |> MapSet.to_list()
+      |> Enum.uniq()
     end
 
     defp fetch_routers!(opts) do
@@ -552,8 +550,7 @@ if Code.ensure_loaded?(Phoenix) do
               endpoint_opts
               |> Keyword.fetch!(:routers)
           end)
-          |> MapSet.new()
-          |> MapSet.to_list()
+          |> Enum.uniq()
 
         router ->
           [router]

--- a/test/prom_ex/plugins/phoenix_test.exs
+++ b/test/prom_ex/plugins/phoenix_test.exs
@@ -93,4 +93,57 @@ defmodule PromEx.Plugins.PhoenixTest do
       assert Phoenix.polling_metrics([]) == []
     end
   end
+
+  describe "router options order preservation" do
+    defp http_tag_values_fn(opts) do
+      [_endpoint_info, http_metrics | _] =
+        Phoenix.event_metrics(Keyword.merge([otp_app: :prom_ex], opts))
+
+      http_metrics.metrics
+      |> List.first()
+      |> Map.get(:tag_values)
+    end
+
+    defp resolve_action(tag_values_fn, path) do
+      conn = %Plug.Conn{method: "GET", request_path: path, host: "localhost", status: 200}
+      tag_values_fn.(%{conn: conn}).action
+    end
+
+    test "first router wins for overlapping routes" do
+      tag_values_fn =
+        http_tag_values_fn(
+          endpoints: [{TestApp.Endpoint, routers: [TestApp.Router, TestApp.OverlapRouter]}]
+        )
+
+      assert resolve_action(tag_values_fn, "/users") == :index
+    end
+
+    test "preserves insertion order when deduplicating routers" do
+      # [Router, OverlapRouter, Router] should deduplicate to [Router, OverlapRouter]
+      tag_values_fn =
+        http_tag_values_fn(
+          endpoints: [
+            {TestApp.Endpoint,
+             routers: [TestApp.Router, TestApp.OverlapRouter, TestApp.Router]}
+          ]
+        )
+
+      # TestApp.Router is first, so its action wins for the overlapping route
+      assert resolve_action(tag_values_fn, "/users") == :index
+    end
+
+    test "keeps first occurrence when deduplicating, not last" do
+      # [OverlapRouter, Router, OverlapRouter] should deduplicate to [OverlapRouter, Router]
+      tag_values_fn =
+        http_tag_values_fn(
+          endpoints: [
+            {TestApp.Endpoint,
+             routers: [TestApp.OverlapRouter, TestApp.Router, TestApp.OverlapRouter]}
+          ]
+        )
+
+      # TestApp.OverlapRouter is first, so its action wins for the overlapping route
+      assert resolve_action(tag_values_fn, "/users") == :overlap_index
+    end
+  end
 end

--- a/test/support/test_app_router.ex
+++ b/test/support/test_app_router.ex
@@ -51,6 +51,14 @@ defmodule TestApp.InternalRouter do
   end
 end
 
+defmodule TestApp.OverlapRouter do
+  use Phoenix.Router
+
+  scope "/", TestApp do
+    get "/users", UserController, :overlap_index
+  end
+end
+
 defmodule TestApp.PlugRouter do
   use Plug.Router
 


### PR DESCRIPTION
### Change description

### What problem does this solve?

Issue number: N/A

I noticed that when passing options to the Phoenix plugin (`:routers`, in my case), the order they were passed in wasn't preserved.
Keeping the routers in order is important to us, because the second router routes overlaps on the first, preventing them from being reported correctly.

Moreover, the current implementation creates a `MapSet` and converts back to a list, which appears suboptimal to me.

To fix this issue, I simply replaced `|> MapSet.new() |> MapSet.to_list()` by `|> Enum.uniq()`.

### Example usage

N/A

### Additional details and screenshots

N/A

### Checklist

- [x] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
