### PR TITLE
Remove unused require statements.

### DIFF
--- a/lib/prom_ex/dashboard_renderer.ex
+++ b/lib/prom_ex/dashboard_renderer.ex
@@ -4,8 +4,6 @@ defmodule PromEx.DashboardRenderer do
   and ensure that requested files actually exist
   """
 
-  require Logger
-
   @type t :: %__MODULE__{
           file_type: :eex | :json | nil,
           relative_path: String.t(),

--- a/lib/prom_ex/plugins/plug_router.ex
+++ b/lib/prom_ex/plugins/plug_router.ex
@@ -109,7 +109,6 @@ if Code.ensure_loaded?(Plug.Router) do
     """
 
     use PromEx.Plugin
-    require Logger
     alias Plug.Conn
 
     @stop_event [:prom_ex, :router, :stop]


### PR DESCRIPTION
### Change description

Removed unused require statements.

### What problem does this solve?

So, elixir 1.20 would not emit compiler warnings. It is a cosmetic change, but needed not having to switch off `--warnings-as-errors` for `mix`.
```
==> prom_ex
Compiling 40 files (.ex)

    warning: unused require Logger
    │
  7 │   require Logger
    │   ~
    │
    └─ lib/prom_ex/dashboard_renderer.ex:7:3

     warning: unused require Logger
     │
 112 │     require Logger
     │     ~
     │
     └─ lib/prom_ex/plugins/plug_router.ex:112:5
```

Issue number: (if applicable)

### Example usage

### Additional details and screenshots

### Checklist

- [ ] I have added unit tests to cover my changes.
- [ ] I have added documentation to cover my changes.
- [x] My changes have passed unit tests and have been tested E2E in an example project.
